### PR TITLE
Añadir filtro opcional por categoría al listado paginado de Conceptos

### DIFF
--- a/Kash/Kash.Api/Controllers/ConceptosController.cs
+++ b/Kash/Kash.Api/Controllers/ConceptosController.cs
@@ -28,14 +28,16 @@ public class ConceptosController : AbsController
         [FromQuery] int pageSize = 10,
         [FromQuery] string searchTerm = "",
         [FromQuery] string sortColumn = "",
-        [FromQuery] string sortOrder = "")
+        [FromQuery] string sortOrder = "",
+        [FromQuery] string? categoriaId = null)
     {
         // OPTIMIZACIÓN: Usamos el helper de la clase base
         if (RequireCurrentUserId(out var usuarioId) is { } unauthorized) return unauthorized;
 
         var query = new GetConceptosPagedListQuery(page, pageSize, searchTerm, sortColumn, sortOrder)
         {
-            UsuarioId = usuarioId
+            UsuarioId = usuarioId,
+            CategoriaId = categoriaId
         };
 
         return await SendAndHandleAsync(query);

--- a/Kash/Kash.Application/Features/Conceptos/Queries/GetPagedList/GetClientesPagedListQueryHandler.cs
+++ b/Kash/Kash.Application/Features/Conceptos/Queries/GetPagedList/GetClientesPagedListQueryHandler.cs
@@ -1,7 +1,9 @@
-﻿using Kash.Domain;
+﻿using Kash.Application.Interfaces;
+using Kash.Domain;
 using SergioIzq.Application.Kernel.Messaging.Abstracts.Queries;
 using SergioIzq.Application.Kernel.Services;
 using Kash.Shared.Application.Dtos;
+using SergioIzq.Domain.Kernel.Abstractions.Results;
 using SergioIzq.Domain.Kernel.Interfaces.Repositories;
 using Kash.Shared.Domain.ValueObjects.Ids;
 
@@ -13,10 +15,49 @@ namespace Kash.Application.Features.Conceptos.Queries;
 public sealed class GetConceptosPagedListQueryHandler
     : GetPagedListQueryHandler<Concepto, ConceptoId, ConceptoDto, GetConceptosPagedListQuery>
 {
+    private readonly IConceptoPaginadoRepository _conceptoPaginadoRepository;
+
     public GetConceptosPagedListQueryHandler(
         IReadRepository<Concepto, ConceptoDto, ConceptoId> repository,
-        ICacheService cacheService)
+        ICacheService cacheService,
+        IConceptoPaginadoRepository conceptoPaginadoRepository)
     : base(repository, cacheService)
     {
+        _conceptoPaginadoRepository = conceptoPaginadoRepository;
+    }
+
+    protected override async Task<PagedList<ConceptoDto>> ApplyFiltersAsync(
+        GetConceptosPagedListQuery query,
+        CancellationToken cancellationToken)
+    {
+        if (!query.UsuarioId.HasValue)
+        {
+            return null!;
+        }
+
+        // Sin categoriaId: mismo comportamiento que antes de este cambio (comportamiento genérico del kernel).
+        if (string.IsNullOrEmpty(query.CategoriaId))
+        {
+            return await _dtoRepository.GetPagedReadModelsByUserAsync(
+                query.UsuarioId.Value,
+                query.Page,
+                query.PageSize,
+                query.SearchTerm,
+                query.SortColumn,
+                query.SortOrder,
+                cancellationToken);
+        }
+
+        // Con categoriaId: el kernel no acepta filtros extra en el paginado, así que se usa
+        // el repositorio Dapper propio (ver IConceptoPaginadoRepository).
+        return await _conceptoPaginadoRepository.GetPagedByCategoriaAsync(
+            query.UsuarioId.Value,
+            Guid.Parse(query.CategoriaId),
+            query.Page,
+            query.PageSize,
+            query.SearchTerm,
+            query.SortColumn,
+            query.SortOrder,
+            cancellationToken);
     }
 }

--- a/Kash/Kash.Application/Features/Conceptos/Queries/GetPagedList/GetConceptosPagedListQuery.cs
+++ b/Kash/Kash.Application/Features/Conceptos/Queries/GetPagedList/GetConceptosPagedListQuery.cs
@@ -15,4 +15,6 @@ public sealed record GetConceptosPagedListQuery : AbsGetPagedListQuery<Concepto,
         : base(page, pageSize, searchTerm ?? "", sortColumn ?? "", sortOrder ?? "")
     {
     }
+
+    public string? CategoriaId { get; init; }
 }

--- a/Kash/Kash.Application/Interfaces/IConceptoPaginadoRepository.cs
+++ b/Kash/Kash.Application/Interfaces/IConceptoPaginadoRepository.cs
@@ -1,0 +1,23 @@
+using Kash.Shared.Application.Dtos;
+using SergioIzq.Domain.Kernel.Abstractions.Results;
+
+namespace Kash.Application.Interfaces;
+
+/// <summary>
+/// Listado paginado de Conceptos filtrado por Categoría. Vive en Application (no en
+/// <c>Kash.Domain</c>, que no referencia <c>Kash.Shared.Application</c> donde vive
+/// <see cref="ConceptoDto"/>) porque <see cref="IReadRepository{T,TDto,TId}.GetPagedReadModelsByUserAsync"/>
+/// del kernel no acepta filtros extra, mismo patrón que <see cref="IGastoHabitualesRepository"/>.
+/// </summary>
+public interface IConceptoPaginadoRepository
+{
+    Task<PagedList<ConceptoDto>> GetPagedByCategoriaAsync(
+        Guid usuarioId,
+        Guid categoriaId,
+        int page,
+        int pageSize,
+        string? searchTerm,
+        string? sortColumn,
+        string? sortOrder,
+        CancellationToken cancellationToken = default);
+}

--- a/Kash/Kash.Infrastructure/DependencyInjection.cs
+++ b/Kash/Kash.Infrastructure/DependencyInjection.cs
@@ -84,6 +84,7 @@ namespace Kash.Infrastructure
             // 6️⃣ Repositorios Manuales (Dashboard + Reportes)
             services.AddScoped<ApplicationInterface.IDashboardRepository, DashboardRepository>();
             services.AddScoped<ApplicationInterface.IReporteRepository, ReporteRepository>();
+            services.AddScoped<ApplicationInterface.IConceptoPaginadoRepository, ConceptoPaginadoRepository>();
             services.AddScoped<ApplicationInterface.IGastoHabitualesRepository, GastoHabitualesRepository>();
             services.AddScoped<ApplicationInterface.IIngresoHabitualesRepository, IngresoHabitualesRepository>();
             services.AddScoped<ApplicationInterface.IGastoSugerenciaRepository, GastoSugerenciaRepository>();

--- a/Kash/Kash.Infrastructure/Persistence/Query/ConceptoPaginadoRepository.cs
+++ b/Kash/Kash.Infrastructure/Persistence/Query/ConceptoPaginadoRepository.cs
@@ -1,0 +1,87 @@
+using Dapper;
+using Kash.Shared.Application.Dtos;
+using SergioIzq.Domain.Kernel.Abstractions.Results;
+using SergioIzq.Infrastructure.Kernel.Persistence;
+using ApplicationInterface = Kash.Application.Interfaces;
+
+namespace Kash.Infrastructure.Persistence.Query;
+
+public sealed class ConceptoPaginadoRepository : ApplicationInterface.IConceptoPaginadoRepository
+{
+    private readonly IDbConnectionFactory _dbConnectionFactory;
+
+    // Mismas columnas sortables que ConceptoReadRepository.ConfigureRepository(), para no abrir
+    // el ORDER BY a una columna arbitraria enviada por query string.
+    private static readonly Dictionary<string, string> SortableColumns = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { "Nombre", "c.nombre" },
+        { "CategoriaNombre", "cat.nombre" },
+        { "FechaCreacion", "c.fecha_creacion" }
+    };
+
+    private const string DefaultOrderBy = "c.nombre ASC";
+
+    public ConceptoPaginadoRepository(IDbConnectionFactory dbConnectionFactory)
+    {
+        _dbConnectionFactory = dbConnectionFactory;
+    }
+
+    public async Task<PagedList<ConceptoDto>> GetPagedByCategoriaAsync(
+        Guid usuarioId,
+        Guid categoriaId,
+        int page,
+        int pageSize,
+        string? searchTerm,
+        string? sortColumn,
+        string? sortOrder,
+        CancellationToken cancellationToken = default)
+    {
+        using var connection = _dbConnectionFactory.CreateConnection();
+
+        var orderByColumn = !string.IsNullOrWhiteSpace(sortColumn) && SortableColumns.TryGetValue(sortColumn, out var mappedColumn)
+            ? mappedColumn
+            : "c.nombre";
+        var orderByDirection = string.Equals(sortOrder, "desc", StringComparison.OrdinalIgnoreCase) ? "DESC" : "ASC";
+        var orderBy = string.IsNullOrWhiteSpace(sortColumn) ? DefaultOrderBy : $"{orderByColumn} {orderByDirection}";
+
+        var parameters = new
+        {
+            UsuarioId = usuarioId,
+            CategoriaId = categoriaId,
+            SearchTerm = searchTerm ?? "",
+            Offset = (page - 1) * pageSize,
+            PageSize = pageSize
+        };
+
+        const string whereClause = @"
+            WHERE c.id_usuario = @UsuarioId
+              AND c.id_categoria = @CategoriaId
+              AND (@SearchTerm = '' OR c.nombre LIKE CONCAT('%', @SearchTerm, '%'))";
+
+        var countSql = $@"
+            SELECT COUNT(*)
+            FROM conceptos c
+            {whereClause}";
+
+        var itemsSql = $@"
+            SELECT
+                c.id as Id,
+                c.nombre as Nombre,
+                c.id_categoria as CategoriaId,
+                COALESCE(cat.nombre, '') as CategoriaNombre,
+                c.id_usuario as UsuarioId
+            FROM conceptos c
+            LEFT JOIN categorias cat ON c.id_categoria = cat.id
+            {whereClause}
+            ORDER BY {orderBy}
+            LIMIT @PageSize OFFSET @Offset";
+
+        var totalCount = await connection.ExecuteScalarAsync<int>(
+            new CommandDefinition(countSql, parameters, cancellationToken: cancellationToken));
+
+        var items = await connection.QueryAsync<ConceptoDto>(
+            new CommandDefinition(itemsSql, parameters, cancellationToken: cancellationToken));
+
+        return new PagedList<ConceptoDto>(items.ToList(), page, pageSize, totalCount);
+    }
+}

--- a/openspec/changes/archive/2026-08-21-conceptos-paginados-por-categoria/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-21-conceptos-paginados-por-categoria/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/archive/2026-08-21-conceptos-paginados-por-categoria/design.md
+++ b/openspec/changes/archive/2026-08-21-conceptos-paginados-por-categoria/design.md
@@ -1,0 +1,43 @@
+## Context
+
+Ver `proposal.md - Why` para la motivación (consumidor: `Kash-Frontend`, change `selectores-catalogo-completo`). Puntos de partida verificados en este repo:
+
+- `ConceptosController.GetPagedList` (`GET /api/conceptos`) delega en `GetConceptosPagedListQuery` → `GetConceptosPagedListQueryHandler` (el archivo está mal nombrado como `GetClientesPagedListQueryHandler.cs`, copia-pega de otro catálogo — no se corrige aquí, fuera de alcance de este cambio). El handler hereda de `GetPagedListQueryHandler<Concepto, ConceptoId, ConceptoDto, GetConceptosPagedListQuery>` **sin sobrescribir `ApplyFiltersAsync`**, así que usa el comportamiento por defecto del kernel (paginación directa vía `GetPagedReadModelsByUserAsync`).
+- `GetGastosPagedListQueryHandler` (mismo kernel) sí sobrescribe `ApplyFiltersAsync` para casos donde hace falta lógica específica, llamando directamente a `_dtoRepository.GetPagedReadModelsByUserAsync(usuarioId, page, pageSize, searchTerm, sortColumn, sortOrder, ct)` — es el precedente a seguir para Conceptos.
+- `IReadRepository<T,TDto,TId>.GetPagedReadModelsByUserAsync(usuarioId, page, pageSize, searchTerm, sortColumn, sortOrder, ct)` (kernel, `SergioIzq.Domain.Kernel`) **no acepta un diccionario de filtros extra** — confirmado por reflexión sobre el ensamblado del paquete (a diferencia de `GetRecentAsync`/`SearchForAutocompleteAsync`, que sí lo aceptan). No hay forma de inyectar `categoriaId` a través de ese método sin ampliar el kernel compartido.
+- `SearchConceptosQueryHandler`/`GetRecentConceptosQueryHandler` ya resuelven el mismo problema para `search`/`recent` sobrescribiendo `GetCustomFilters()`, que sí es un hook soportado por `GetRecentQueryHandler`/`SearchForAutocompleteQueryHandler` — pero ese hook no existe en `GetPagedListQueryHandler`.
+- El cambio `sugerencias-y-habituales-transacciones` (ya archivado en este repo) estableció el patrón para estos casos: un repositorio de agregación/consulta propio en `Kash.Application/Interfaces` (no en `Kash.Domain`, que no referencia `Kash.Shared.Application` donde viven los DTOs), implementado con Dapper en `Kash.Infrastructure/Persistence/Query`, registrado manualmente en DI.
+- `ConceptoReadRepository.ConfigureRepository()` (`Kash.Infrastructure/Persistence/Data/Conceptos/`) ya define alias `c` para la tabla `conceptos`, con joins/columnas ya usados por `search`/`recent` — mismo alias y columnas que se necesitan para el filtro paginado.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Permitir filtrar por `categoriaId` el listado paginado de Conceptos, manteniendo `searchTerm`/orden/paginación existentes.
+- No romper el comportamiento actual cuando no se informa `categoriaId`.
+
+**Non-Goals:**
+- No se corrige el nombre de archivo mal puesto (`GetClientesPagedListQueryHandler.cs` para el handler de Conceptos) — fuera de alcance, señalado pero no tocado.
+- No se amplía `IReadRepository`/`GetPagedListQueryHandler` del paquete kernel compartido con un hook de filtros extra genérico — se resuelve de forma local a Conceptos, igual que ya se hizo para `habituales`/`sugerencia`.
+- No se añade filtro por categoría a ningún otro catálogo — ninguno de los otros 6 lo necesita (confirmado en `Kash-Frontend`, ninguno de sus stores pasa un filtro secundario a `search`).
+
+## Decisions
+
+**1. `GetConceptosPagedListQueryHandler` sobrescribe `ApplyFiltersAsync`: delega en el comportamiento genérico si no hay `categoriaId`, y en un método Dapper propio si lo hay.**
+Cuando `query.CategoriaId` es nulo/vacío, se comporta exactamente igual que hoy (llamando a `_dtoRepository.GetPagedReadModelsByUserAsync(...)` directamente, mismo patrón que `GetGastosPagedListQueryHandler`). Cuando `categoriaId` viene informado, se llama a un método nuevo (`IConceptoPaginadoRepository.GetPagedByCategoriaAsync(usuarioId, categoriaId, page, pageSize, searchTerm, sortColumn, sortOrder, ct)`) implementado con Dapper en `ConceptoReadRepository`-equivalente en `Kash.Infrastructure/Persistence/Query/`, filtrando por `c.id_categoria = @CategoriaId` además de `c.id_usuario = @UsuarioId`, reutilizando `searchTerm` sobre `c.nombre` igual que el listado genérico.
+*Alternativa descartada*: ampliar `GetPagedReadModelsByUserAsync` del kernel para aceptar un diccionario de filtros extra (como ya tiene `GetRecentAsync`) — sería la solución "correcta" a largo plazo, pero toca un paquete compartido fuera de este repo (`SergioIzq.Domain.Kernel`/`SergioIzq.Infrastructure.Kernel`), con impacto en todos los consumidores de esa librería, no solo Kash. Se descarta para este cambio; si en el futuro aparecen más casos similares, valorar proponerlo en el kernel entonces.
+
+**2. El nuevo repositorio (`IConceptoPaginadoRepository`) vive en `Kash.Application/Interfaces`, no extiende `IConceptoReadRepository` de `Kash.Domain`.**
+Mismo motivo que en `sugerencias-y-habituales-transacciones`: `Kash.Domain.csproj` no referencia `Kash.Shared.Application` (donde vive `ConceptoDto`), así que una interfaz de Domain no puede declarar un método que devuelva `PagedList<ConceptoDto>`. Se sigue el patrón ya usado por `IGastoHabitualesRepository`/`IGastoSugerenciaRepository`: interfaz en Application, implementación Dapper en Infrastructure, registro manual en DI (no vía el escaneo automático de Scrutor que cubre las interfaces marcador de Domain).
+
+**3. Sin caché para este endpoint, igual que el listado paginado de Conceptos ya no la tiene hoy.**
+El listado paginado genérico (`GetPagedListQueryHandler`) no aplica caché de lista completa como sí hace `GetRecentQueryHandler` (30s) — no se introduce ninguna donde no la había, para no cambiar el comportamiento de frescura ya esperado por el listado paginado.
+
+## Risks / Trade-offs
+
+- **[Riesgo] Solución específica a Conceptos, no reutilizable si aparece un caso similar en otro catálogo.** Aceptado: hoy ningún otro catálogo necesita un filtro secundario en su paginado (verificado en el frontend), así que generalizar ahora sería especular sobre una necesidad que no existe todavía.
+- **[Riesgo] Dos caminos de código en el mismo handler** (`ApplyFiltersAsync` con y sin `categoriaId`) en vez de un único camino — algo más de código que un solo método, pero evita cualquier cambio de comportamiento para el caso ya existente (sin `categoriaId`), que es el más usado hoy (pantalla de listado de Conceptos).
+- **[Riesgo] Nombre de archivo del handler ya está equivocado** (`GetClientesPagedListQueryHandler.cs` para Conceptos) — no se corrige aquí para no mezclar un cambio de higiene de código con este cambio funcional; queda anotado para quien quiera limpiarlo en otro momento.
+
+## Migration Plan
+
+No aplica migración de datos ni cambios de esquema: el filtro opera sobre la columna `id_categoria` ya existente en `conceptos`. Sin rollback especial: el parámetro es opcional y aditivo; el comportamiento sin `categoriaId` no cambia.

--- a/openspec/changes/archive/2026-08-21-conceptos-paginados-por-categoria/proposal.md
+++ b/openspec/changes/archive/2026-08-21-conceptos-paginados-por-categoria/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+El frontend (`Kash-Frontend`, change `selectores-catalogo-completo`) quiere que los selectores de catálogo (Concepto, Categoría, Cuenta, Forma de Pago, Proveedor/Cliente, Persona) dejen de limitarse a "recientes" o a resultados de búsqueda por texto, y permitan recorrer con scroll el catálogo completo del usuario, reutilizando los endpoints paginados ya existentes. Para 6 de los 7 catálogos, el endpoint paginado ya sirve tal cual. Para Concepto no: cuando el usuario ya tiene una Categoría elegida, el selector de Concepto necesita mostrar solo los Conceptos de esa Categoría, y el endpoint paginado de Conceptos (`GET /api/conceptos`) no soporta ese filtro hoy — solo lo soportan `search` y `recent`.
+
+## What Changes
+
+- Añadir un parámetro opcional `categoriaId` a `GET /api/conceptos` (listado paginado), que cuando se informa restringe los Conceptos devueltos a los de esa Categoría, además de la paginación/búsqueda/orden ya existentes.
+- Sin cambios en `search`/`recent` de Conceptos (ya soportan `categoriaId` desde antes) ni en ningún otro catálogo (Categoria, Cuenta, FormaPago, Proveedor, Persona, Cliente no necesitan cambios: su endpoint paginado ya sirve "todos los del usuario" sin depender de ningún filtro secundario).
+
+## Capabilities
+
+### New Capabilities
+- `conceptos-filtrado-por-categoria-en-listado`: filtrado opcional por `categoriaId` en el listado paginado de Conceptos.
+
+### Modified Capabilities
+(ninguna — no existe spec previa que capture el comportamiento actual del listado paginado de Conceptos)
+
+## Impact
+
+- **`Kash.Api`**: `ConceptosController.GetPagedList` gana un parámetro `[FromQuery] string? categoriaId`.
+- **`Kash.Application`**: `GetConceptosPagedListQuery` gana una propiedad `CategoriaId` opcional; `GetConceptosPagedListQueryHandler` (hoy 100% genérico, sin `ApplyFiltersAsync` propio) necesita aplicar ese filtro.
+- **`Kash.Domain`/`Kash.Infrastructure`**: el método del kernel del que depende hoy el paginado (`IReadRepository.GetPagedReadModelsByUserAsync`) no acepta filtros extra (a diferencia de `GetRecentAsync`/`SearchForAutocompleteAsync`, confirmado por reflexión sobre `SergioIzq.Domain.Kernel`); se necesita un método propio en `ConceptoReadRepository` (Dapper), mismo patrón que los métodos custom ya existentes (`GetHabitualesAsync`, `GetUltimoUsoAsync` de la propuesta `sugerencias-y-habituales-transacciones`), sin tocar el paquete kernel compartido.
+- **Consumidor externo**: `Kash-Frontend`, change `selectores-catalogo-completo` (repo separado, sin acoplamiento de código — solo de contrato HTTP).

--- a/openspec/changes/archive/2026-08-21-conceptos-paginados-por-categoria/specs/conceptos-filtrado-por-categoria-en-listado/spec.md
+++ b/openspec/changes/archive/2026-08-21-conceptos-paginados-por-categoria/specs/conceptos-filtrado-por-categoria-en-listado/spec.md
@@ -1,0 +1,27 @@
+## Purpose
+
+Permitir filtrar por Categoría el listado paginado de Conceptos, para que un cliente pueda recorrer con scroll el catálogo completo de Conceptos de una Categoría concreta, en vez de limitarse a los resultados de búsqueda por texto o a los más recientes.
+
+## ADDED Requirements
+
+### Requirement: Filtro opcional por categoría en el listado paginado de Conceptos
+El sistema SHALL aceptar un parámetro opcional `categoriaId` en el listado paginado de Conceptos que, cuando se informa, restringe los Conceptos devueltos a los que pertenecen a esa Categoría, manteniendo la paginación, el orden y la búsqueda por texto ya existentes.
+
+#### Scenario: Listado filtrado por categoría
+- **WHEN** un usuario autenticado solicita el listado paginado de Conceptos indicando un `categoriaId`
+- **THEN** el sistema devuelve únicamente los Conceptos de ese usuario que pertenecen a esa Categoría, paginados según lo solicitado
+
+#### Scenario: Listado sin filtro de categoría
+- **WHEN** un usuario autenticado solicita el listado paginado de Conceptos sin indicar `categoriaId`
+- **THEN** el sistema devuelve todos los Conceptos de ese usuario, exactamente igual que antes de este cambio
+
+#### Scenario: Categoría sin conceptos
+- **WHEN** un usuario autenticado solicita el listado paginado de Conceptos filtrado por una Categoría que no tiene ningún Concepto asociado
+- **THEN** el sistema devuelve una página vacía, sin error
+
+### Requirement: Aislamiento entre usuarios
+El sistema SHALL aplicar el filtro por categoría únicamente sobre los Conceptos del usuario autenticado, sin exponer Conceptos de otros usuarios aunque coincida el `categoriaId`.
+
+#### Scenario: categoriaId de otro usuario
+- **WHEN** un usuario autenticado solicita el listado paginado de Conceptos filtrado por un `categoriaId` que pertenece a otro usuario
+- **THEN** el sistema no devuelve Conceptos de ese otro usuario; se comporta igual que si la categoría no tuviera Conceptos propios

--- a/openspec/changes/archive/2026-08-21-conceptos-paginados-por-categoria/tasks.md
+++ b/openspec/changes/archive/2026-08-21-conceptos-paginados-por-categoria/tasks.md
@@ -1,0 +1,22 @@
+## 1. Contrato de la query
+
+- [x] 1.1 Añadida propiedad `CategoriaId` opcional (`string?`, mismo tipo que ya usan `SearchConceptosQuery`/`GetRecentConceptosQuery`) a `GetConceptosPagedListQuery`
+- [x] 1.2 Añadido parámetro `[FromQuery] string? categoriaId` a `ConceptosController.GetPagedList`, pasado a la query
+
+## 2. Repositorio de agregación (capability: conceptos-filtrado-por-categoria-en-listado)
+
+- [x] 2.1 Creada `IConceptoPaginadoRepository` en `Kash.Application/Interfaces/` con `GetPagedByCategoriaAsync(Guid usuarioId, Guid categoriaId, int page, int pageSize, string? searchTerm, string? sortColumn, string? sortOrder, CancellationToken ct)`, mismo patrón que `IGastoHabitualesRepository`
+- [x] 2.2 Implementado `ConceptoPaginadoRepository` en `Kash.Infrastructure/Persistence/Query/` con Dapper: mismas columnas/joins que `ConceptoReadRepository.ConfigureRepository()` (alias `c`), `WHERE c.id_usuario = @UsuarioId AND c.id_categoria = @CategoriaId`, `searchTerm` opcional sobre `c.nombre` (`LIKE`), whitelist de columnas sortables (`Nombre`/`CategoriaNombre`/`FechaCreacion`, igual que `ConfigureRepository()`) para no exponer el `ORDER BY` a la query string, `LIMIT/OFFSET` según `page`/`pageSize`, más una consulta de conteo total; devuelve `PagedList<ConceptoDto>` (confirmado por reflexión sobre `SergioIzq.Domain.Kernel` que su constructor es `(List<T> items, int page, int pageSize, int totalCount)`); registrado en DI (`Kash.Infrastructure/DependencyInjection.cs`)
+- [x] 2.3 Verificado contra `AhorroLandTest` (BD de test) con el usuario real de prueba, que tiene un Concepto en cada una de sus 4 Categorías (IA/Claude, Ocio/Gimnasio, Sin clasificar/Importado del banco, categoria/concepto): `GET /api/conceptos?categoriaId=...` para cada una de las 4 Categorías devuelve únicamente su propio Concepto (`allMatchCategoria: true` en los 4 casos), sin mezclar Conceptos de otras Categorías; paginación (`page`/`pageSize`/`hasNextPage`) correcta; una Categoría sin Conceptos (GUID inexistente) devuelve página vacía sin error
+
+## 3. Handler
+
+- [x] 3.1 Sobrescrito `ApplyFiltersAsync` en `GetConceptosPagedListQueryHandler` (archivo `GetClientesPagedListQueryHandler.cs`, nombre ya mal puesto de antes, no corregido aquí): si `query.CategoriaId` es nulo/vacío, mantiene el comportamiento actual (`_dtoRepository.GetPagedReadModelsByUserAsync(...)`, mismo patrón que `GetGastosPagedListQueryHandler`); si viene informado, llama a `IConceptoPaginadoRepository.GetPagedByCategoriaAsync(...)` parseando `query.CategoriaId` a `Guid`
+- [x] 3.2 Verificado contra `AhorroLandTest`: `GET /api/conceptos?page=1&pageSize=50` sin `categoriaId` sigue devolviendo los 4 Conceptos del usuario (mismo `totalCount` y mismos ítems que antes de este cambio, camino genérico `_dtoRepository.GetPagedReadModelsByUserAsync` sin tocar)
+
+## 4. Aislamiento y validación final
+
+- [ ] 4.1 Verificar manualmente que un `categoriaId` perteneciente a otro usuario no devuelve Conceptos de ese otro usuario (el filtro por `id_usuario` sigue aplicándose siempre, no solo cuando no hay `categoriaId`)
+- [x] 4.2 `dotnet build` de `Kash.Application`/`Kash.Infrastructure` (aislados) y `dotnet build Kash.sln` completo: compilación sin errores ni avisos
+- [x] 4.3 Confirmado con `Kash-Frontend` (change `selectores-catalogo-completo`, `concepto.service.ts`): el parámetro `categoriaId` y la forma de la respuesta (`items`/`page`/`pageSize`/`totalCount`/`hasNextPage`/`hasPreviousPage`, `PaginatedList<T>` del frontend) coinciden con `PagedList<ConceptoDto>` del backend
+- [x] 4.4 `openspec validate conceptos-paginados-por-categoria --strict`: "Change 'conceptos-paginados-por-categoria' is valid"

--- a/openspec/specs/conceptos-filtrado-por-categoria-en-listado/spec.md
+++ b/openspec/specs/conceptos-filtrado-por-categoria-en-listado/spec.md
@@ -1,0 +1,29 @@
+# conceptos-filtrado-por-categoria-en-listado Specification
+
+## Purpose
+
+Permitir filtrar por Categoría el listado paginado de Conceptos, para que un cliente pueda recorrer con scroll el catálogo completo de Conceptos de una Categoría concreta, en vez de limitarse a los resultados de búsqueda por texto o a los más recientes.
+
+## Requirements
+
+### Requirement: Filtro opcional por categoría en el listado paginado de Conceptos
+El sistema SHALL aceptar un parámetro opcional `categoriaId` en el listado paginado de Conceptos que, cuando se informa, restringe los Conceptos devueltos a los que pertenecen a esa Categoría, manteniendo la paginación, el orden y la búsqueda por texto ya existentes.
+
+#### Scenario: Listado filtrado por categoría
+- **WHEN** un usuario autenticado solicita el listado paginado de Conceptos indicando un `categoriaId`
+- **THEN** el sistema devuelve únicamente los Conceptos de ese usuario que pertenecen a esa Categoría, paginados según lo solicitado
+
+#### Scenario: Listado sin filtro de categoría
+- **WHEN** un usuario autenticado solicita el listado paginado de Conceptos sin indicar `categoriaId`
+- **THEN** el sistema devuelve todos los Conceptos de ese usuario, exactamente igual que antes de este cambio
+
+#### Scenario: Categoría sin conceptos
+- **WHEN** un usuario autenticado solicita el listado paginado de Conceptos filtrado por una Categoría que no tiene ningún Concepto asociado
+- **THEN** el sistema devuelve una página vacía, sin error
+
+### Requirement: Aislamiento entre usuarios
+El sistema SHALL aplicar el filtro por categoría únicamente sobre los Conceptos del usuario autenticado, sin exponer Conceptos de otros usuarios aunque coincida el `categoriaId`.
+
+#### Scenario: categoriaId de otro usuario
+- **WHEN** un usuario autenticado solicita el listado paginado de Conceptos filtrado por un `categoriaId` que pertenece a otro usuario
+- **THEN** el sistema no devuelve Conceptos de ese otro usuario; se comporta igual que si la categoría no tuviera Conceptos propios


### PR DESCRIPTION
## Motivo de los cambios
El frontend (Kash-Frontend, change selectores-catalogo-completo) quiere que los
selectores de catálogo permitan recorrer con scroll el catálogo completo del
usuario en vez de limitarse a "recientes" o a búsqueda por texto. Para 6 de los
7 catálogos el endpoint paginado ya servía tal cual, pero el selector de
Concepto necesita, cuando ya hay una Categoría elegida, mostrar solo los
Conceptos de esa Categoría — y el listado paginado de Conceptos (`GET
/api/conceptos`) no soportaba ese filtro (solo lo soportaban `search` y `recent`).

## Descripción de la solución
- `GetConceptosPagedListQuery` gana una propiedad `CategoriaId` opcional
  (`string?`, mismo tipo que ya usan `SearchConceptosQuery`/`GetRecentConceptosQuery`);
  `ConceptosController.GetPagedList` acepta `[FromQuery] string? categoriaId`.
- Nuevo `IConceptoPaginadoRepository` (`Kash.Application/Interfaces/`) con
  `GetPagedByCategoriaAsync`, implementado con Dapper en
  `ConceptoPaginadoRepository` (`Kash.Infrastructure/Persistence/Query/`): mismas
  columnas/joins que `ConceptoReadRepository.ConfigureRepository()`, `WHERE` por
  `id_usuario` + `id_categoria`, `searchTerm` opcional, whitelist de columnas
  ordenables, `LIMIT/OFFSET` + conteo total; registrado en DI.
- `GetConceptosPagedListQueryHandler` (archivo `GetClientesPagedListQueryHandler.cs`,
  ya mal nombrado de antes) sobrescribe `ApplyFiltersAsync`: sin `categoriaId`
  mantiene el comportamiento genérico de siempre; con `categoriaId` delega en el
  repositorio nuevo.
- Verificado contra la BD de test (`AhorroLandTest`) con datos reales: cada
  `categoriaId` devuelve solo sus propios Conceptos, sin mezclar categorías;
  paginación correcta; sin `categoriaId` el listado no cambia respecto a antes.
  Sin verificar el caso de `categoriaId` perteneciente a otro usuario (solo hay
  una cuenta de prueba disponible), documentado como tarea abierta en el change
  archivado.

## Archivos modificados
- `Kash/Kash.Api/Controllers/ConceptosController.cs`
- `Kash/Kash.Application/Features/Conceptos/Queries/GetPagedList/GetClientesPagedListQueryHandler.cs`
- `Kash/Kash.Application/Features/Conceptos/Queries/GetPagedList/GetConceptosPagedListQuery.cs`
- `Kash/Kash.Infrastructure/DependencyInjection.cs`
- `Kash/Kash.Application/Interfaces/IConceptoPaginadoRepository.cs` (nuevo)
- `Kash/Kash.Infrastructure/Persistence/Query/ConceptoPaginadoRepository.cs` (nuevo)
- `openspec/specs/conceptos-filtrado-por-categoria-en-listado/spec.md` (nuevo)
- `openspec/changes/archive/2026-08-21-conceptos-paginados-por-categoria/` (change archivado)