### PR TITLE
Añadir exportación a Excel de Gastos e Ingresos con filtros combinables

### DIFF
--- a/Kash/Kash.Api/Controllers/GastosController.cs
+++ b/Kash/Kash.Api/Controllers/GastosController.cs
@@ -1,5 +1,6 @@
 ﻿using Kash.Application.Features.Gastos.Commands;
 using Kash.Application.Features.Gastos.Queries;
+using Kash.Application.Features.Gastos.Queries.GetExcel;
 using Kash.Application.Features.Gastos.Queries.Habituales;
 using Kash.Application.Features.Gastos.Queries.Sugerencia;
 using MediatR;
@@ -39,6 +40,36 @@ public class GastosController : AbsController
         };
 
         return await SendAndHandleAsync(query);
+    }
+
+    /// <summary>
+    /// Genera y descarga un Excel con los Gastos del usuario que cumplen los filtros indicados
+    /// (todos opcionales y combinables), sin paginar.
+    /// </summary>
+    [HttpGet("excel")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetExcel(
+        [FromQuery] DateTime? fechaInicio,
+        [FromQuery] DateTime? fechaFin,
+        [FromQuery] string? searchTerm,
+        [FromQuery] Guid[]? conceptoIds,
+        [FromQuery] Guid[]? categoriaIds,
+        [FromQuery] Guid[]? proveedorIds,
+        [FromQuery] Guid[]? personaIds,
+        CancellationToken cancellationToken)
+    {
+        if (RequireCurrentUserId(out var usuarioId) is { } unauthorized) return unauthorized;
+
+        var query = new GetGastosExcelQuery(usuarioId, fechaInicio, fechaFin, searchTerm, conceptoIds, categoriaIds, proveedorIds, personaIds);
+        var result = await _sender.Send(query, cancellationToken);
+
+        if (result.IsSuccess)
+        {
+            return File(result.Value.Contenido, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", result.Value.NombreArchivo);
+        }
+
+        return HandleResult(result);
     }
 
     [HttpGet("{id}")]

--- a/Kash/Kash.Api/Controllers/IngresosController.cs
+++ b/Kash/Kash.Api/Controllers/IngresosController.cs
@@ -1,5 +1,6 @@
 ﻿using Kash.Application.Features.Ingresos.Commands;
 using Kash.Application.Features.Ingresos.Queries;
+using Kash.Application.Features.Ingresos.Queries.GetExcel;
 using Kash.Application.Features.Ingresos.Queries.Habituales;
 using Kash.Application.Features.Ingresos.Queries.Sugerencia;
 using SergioIzq.AspNetCore.Kernel.Controllers;
@@ -39,6 +40,36 @@ public class IngresosController : AbsController
         };
 
         return await SendAndHandleAsync(query);
+    }
+
+    /// <summary>
+    /// Genera y descarga un Excel con los Ingresos del usuario que cumplen los filtros indicados
+    /// (todos opcionales y combinables), sin paginar.
+    /// </summary>
+    [HttpGet("excel")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetExcel(
+        [FromQuery] DateTime? fechaInicio,
+        [FromQuery] DateTime? fechaFin,
+        [FromQuery] string? searchTerm,
+        [FromQuery] Guid[]? conceptoIds,
+        [FromQuery] Guid[]? categoriaIds,
+        [FromQuery] Guid[]? clienteIds,
+        [FromQuery] Guid[]? personaIds,
+        CancellationToken cancellationToken)
+    {
+        if (RequireCurrentUserId(out var usuarioId) is { } unauthorized) return unauthorized;
+
+        var query = new GetIngresosExcelQuery(usuarioId, fechaInicio, fechaFin, searchTerm, conceptoIds, categoriaIds, clienteIds, personaIds);
+        var result = await _sender.Send(query, cancellationToken);
+
+        if (result.IsSuccess)
+        {
+            return File(result.Value.Contenido, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", result.Value.NombreArchivo);
+        }
+
+        return HandleResult(result);
     }
 
     [HttpGet("{id}")]

--- a/Kash/Kash.Application/Features/Gastos/Queries/GetExcel/GetGastosExcelQuery.cs
+++ b/Kash/Kash.Application/Features/Gastos/Queries/GetExcel/GetGastosExcelQuery.cs
@@ -1,0 +1,19 @@
+using SergioIzq.Application.Kernel.Messaging;
+using Kash.Shared.Application.Dtos.Reportes;
+
+namespace Kash.Application.Features.Gastos.Queries.GetExcel;
+
+/// <summary>
+/// Genera el Excel con los Gastos del usuario que cumplen los filtros indicados
+/// (todos opcionales y combinables), sin paginar.
+/// </summary>
+public sealed record GetGastosExcelQuery(
+    Guid UsuarioId,
+    DateTime? FechaInicio,
+    DateTime? FechaFin,
+    string? SearchTerm,
+    Guid[]? ConceptoIds,
+    Guid[]? CategoriaIds,
+    Guid[]? ProveedorIds,
+    Guid[]? PersonaIds
+) : IQuery<PresupuestoArchivoDto>;

--- a/Kash/Kash.Application/Features/Gastos/Queries/GetExcel/GetGastosExcelQueryHandler.cs
+++ b/Kash/Kash.Application/Features/Gastos/Queries/GetExcel/GetGastosExcelQueryHandler.cs
@@ -1,0 +1,61 @@
+using System.Globalization;
+using Kash.Application.Interfaces;
+using SergioIzq.Application.Kernel.Messaging;
+using Kash.Shared.Application.Dtos.Reportes;
+using SergioIzq.Domain.Kernel.Abstractions.Results;
+
+namespace Kash.Application.Features.Gastos.Queries.GetExcel;
+
+/// <summary>
+/// Obtiene los Gastos del usuario que cumplen los filtros indicados y los renderiza como Excel.
+/// </summary>
+public sealed class GetGastosExcelQueryHandler : IQueryHandler<GetGastosExcelQuery, PresupuestoArchivoDto>
+{
+    private readonly IGastoExportRepository _exportRepository;
+    private readonly IGastoExcelGenerator _excelGenerator;
+
+    public GetGastosExcelQueryHandler(
+        IGastoExportRepository exportRepository,
+        IGastoExcelGenerator excelGenerator)
+    {
+        _exportRepository = exportRepository;
+        _excelGenerator = excelGenerator;
+    }
+
+    public async Task<Result<PresupuestoArchivoDto>> Handle(
+        GetGastosExcelQuery request,
+        CancellationToken cancellationToken)
+    {
+        if (request.UsuarioId == Guid.Empty)
+        {
+            return Result.Failure<PresupuestoArchivoDto>(
+                Error.Validation("El ID del usuario no puede estar vacío."));
+        }
+
+        if (request.FechaInicio.HasValue && request.FechaFin.HasValue && request.FechaInicio > request.FechaFin)
+        {
+            return Result.Failure<PresupuestoArchivoDto>(
+                Error.Validation("La fecha de inicio no puede ser posterior a la fecha de fin."));
+        }
+
+        var filtro = new GastoExportFiltro(
+            request.FechaInicio,
+            request.FechaFin,
+            request.SearchTerm,
+            request.ConceptoIds,
+            request.CategoriaIds,
+            request.ProveedorIds,
+            request.PersonaIds);
+
+        var datos = await _exportRepository.GetForExportAsync(request.UsuarioId, filtro, cancellationToken);
+
+        var excel = _excelGenerator.Generar(datos);
+
+        var nombre = string.Format(
+            CultureInfo.InvariantCulture,
+            "gastos_{0:yyyyMMdd}.xlsx",
+            DateTime.UtcNow);
+
+        return Result.Success(new PresupuestoArchivoDto(nombre, excel));
+    }
+}

--- a/Kash/Kash.Application/Features/Ingresos/Queries/GetExcel/GetIngresosExcelQuery.cs
+++ b/Kash/Kash.Application/Features/Ingresos/Queries/GetExcel/GetIngresosExcelQuery.cs
@@ -1,0 +1,19 @@
+using SergioIzq.Application.Kernel.Messaging;
+using Kash.Shared.Application.Dtos.Reportes;
+
+namespace Kash.Application.Features.Ingresos.Queries.GetExcel;
+
+/// <summary>
+/// Genera el Excel con los Ingresos del usuario que cumplen los filtros indicados
+/// (todos opcionales y combinables), sin paginar.
+/// </summary>
+public sealed record GetIngresosExcelQuery(
+    Guid UsuarioId,
+    DateTime? FechaInicio,
+    DateTime? FechaFin,
+    string? SearchTerm,
+    Guid[]? ConceptoIds,
+    Guid[]? CategoriaIds,
+    Guid[]? ClienteIds,
+    Guid[]? PersonaIds
+) : IQuery<PresupuestoArchivoDto>;

--- a/Kash/Kash.Application/Features/Ingresos/Queries/GetExcel/GetIngresosExcelQueryHandler.cs
+++ b/Kash/Kash.Application/Features/Ingresos/Queries/GetExcel/GetIngresosExcelQueryHandler.cs
@@ -1,0 +1,61 @@
+using System.Globalization;
+using Kash.Application.Interfaces;
+using SergioIzq.Application.Kernel.Messaging;
+using Kash.Shared.Application.Dtos.Reportes;
+using SergioIzq.Domain.Kernel.Abstractions.Results;
+
+namespace Kash.Application.Features.Ingresos.Queries.GetExcel;
+
+/// <summary>
+/// Obtiene los Ingresos del usuario que cumplen los filtros indicados y los renderiza como Excel.
+/// </summary>
+public sealed class GetIngresosExcelQueryHandler : IQueryHandler<GetIngresosExcelQuery, PresupuestoArchivoDto>
+{
+    private readonly IIngresoExportRepository _exportRepository;
+    private readonly IIngresoExcelGenerator _excelGenerator;
+
+    public GetIngresosExcelQueryHandler(
+        IIngresoExportRepository exportRepository,
+        IIngresoExcelGenerator excelGenerator)
+    {
+        _exportRepository = exportRepository;
+        _excelGenerator = excelGenerator;
+    }
+
+    public async Task<Result<PresupuestoArchivoDto>> Handle(
+        GetIngresosExcelQuery request,
+        CancellationToken cancellationToken)
+    {
+        if (request.UsuarioId == Guid.Empty)
+        {
+            return Result.Failure<PresupuestoArchivoDto>(
+                Error.Validation("El ID del usuario no puede estar vacío."));
+        }
+
+        if (request.FechaInicio.HasValue && request.FechaFin.HasValue && request.FechaInicio > request.FechaFin)
+        {
+            return Result.Failure<PresupuestoArchivoDto>(
+                Error.Validation("La fecha de inicio no puede ser posterior a la fecha de fin."));
+        }
+
+        var filtro = new IngresoExportFiltro(
+            request.FechaInicio,
+            request.FechaFin,
+            request.SearchTerm,
+            request.ConceptoIds,
+            request.CategoriaIds,
+            request.ClienteIds,
+            request.PersonaIds);
+
+        var datos = await _exportRepository.GetForExportAsync(request.UsuarioId, filtro, cancellationToken);
+
+        var excel = _excelGenerator.Generar(datos);
+
+        var nombre = string.Format(
+            CultureInfo.InvariantCulture,
+            "ingresos_{0:yyyyMMdd}.xlsx",
+            DateTime.UtcNow);
+
+        return Result.Success(new PresupuestoArchivoDto(nombre, excel));
+    }
+}

--- a/Kash/Kash.Application/Interfaces/IGastoExcelGenerator.cs
+++ b/Kash/Kash.Application/Interfaces/IGastoExcelGenerator.cs
@@ -1,0 +1,12 @@
+using Kash.Shared.Application.Dtos;
+
+namespace Kash.Application.Interfaces;
+
+/// <summary>
+/// Renderiza un listado de Gastos como un libro Excel de detalle (una fila por Gasto).
+/// </summary>
+public interface IGastoExcelGenerator
+{
+    /// <summary>Genera el Excel (.xlsx) y devuelve su contenido en memoria.</summary>
+    byte[] Generar(IReadOnlyList<GastoDto> datos);
+}

--- a/Kash/Kash.Application/Interfaces/IGastoExportRepository.cs
+++ b/Kash/Kash.Application/Interfaces/IGastoExportRepository.cs
@@ -1,0 +1,26 @@
+using Kash.Shared.Application.Dtos;
+
+namespace Kash.Application.Interfaces;
+
+/// <summary>
+/// Filtros opcionales y combinables para la exportación de Gastos. Un filtro con lista vacía
+/// o nula no restringe el resultado por ese campo.
+/// </summary>
+public sealed record GastoExportFiltro(
+    DateTime? FechaInicio,
+    DateTime? FechaFin,
+    string? SearchTerm,
+    Guid[]? ConceptoIds,
+    Guid[]? CategoriaIds,
+    Guid[]? ProveedorIds,
+    Guid[]? PersonaIds);
+
+/// <summary>
+/// Listado completo (sin paginar) de Gastos de un usuario que cumplen un conjunto de filtros
+/// combinables. Vive en Application (no en Domain, que no referencia Kash.Shared.Application
+/// donde vive <see cref="GastoDto"/>), mismo patrón que <see cref="IConceptoPaginadoRepository"/>.
+/// </summary>
+public interface IGastoExportRepository
+{
+    Task<IReadOnlyList<GastoDto>> GetForExportAsync(Guid usuarioId, GastoExportFiltro filtro, CancellationToken cancellationToken = default);
+}

--- a/Kash/Kash.Application/Interfaces/IIngresoExcelGenerator.cs
+++ b/Kash/Kash.Application/Interfaces/IIngresoExcelGenerator.cs
@@ -1,0 +1,12 @@
+using Kash.Shared.Application.Dtos;
+
+namespace Kash.Application.Interfaces;
+
+/// <summary>
+/// Renderiza un listado de Ingresos como un libro Excel de detalle (una fila por Ingreso).
+/// </summary>
+public interface IIngresoExcelGenerator
+{
+    /// <summary>Genera el Excel (.xlsx) y devuelve su contenido en memoria.</summary>
+    byte[] Generar(IReadOnlyList<IngresoDto> datos);
+}

--- a/Kash/Kash.Application/Interfaces/IIngresoExportRepository.cs
+++ b/Kash/Kash.Application/Interfaces/IIngresoExportRepository.cs
@@ -1,0 +1,25 @@
+using Kash.Shared.Application.Dtos;
+
+namespace Kash.Application.Interfaces;
+
+/// <summary>
+/// Filtros opcionales y combinables para la exportación de Ingresos. Un filtro con lista vacía
+/// o nula no restringe el resultado por ese campo.
+/// </summary>
+public sealed record IngresoExportFiltro(
+    DateTime? FechaInicio,
+    DateTime? FechaFin,
+    string? SearchTerm,
+    Guid[]? ConceptoIds,
+    Guid[]? CategoriaIds,
+    Guid[]? ClienteIds,
+    Guid[]? PersonaIds);
+
+/// <summary>
+/// Listado completo (sin paginar) de Ingresos de un usuario que cumplen un conjunto de filtros
+/// combinables. Mismo patrón que <see cref="IGastoExportRepository"/>.
+/// </summary>
+public interface IIngresoExportRepository
+{
+    Task<IReadOnlyList<IngresoDto>> GetForExportAsync(Guid usuarioId, IngresoExportFiltro filtro, CancellationToken cancellationToken = default);
+}

--- a/Kash/Kash.Infrastructure/DependencyInjection.cs
+++ b/Kash/Kash.Infrastructure/DependencyInjection.cs
@@ -89,8 +89,12 @@ namespace Kash.Infrastructure
             services.AddScoped<ApplicationInterface.IIngresoHabitualesRepository, IngresoHabitualesRepository>();
             services.AddScoped<ApplicationInterface.IGastoSugerenciaRepository, GastoSugerenciaRepository>();
             services.AddScoped<ApplicationInterface.IIngresoSugerenciaRepository, IngresoSugerenciaRepository>();
+            services.AddScoped<ApplicationInterface.IGastoExportRepository, GastoExportRepository>();
+            services.AddScoped<ApplicationInterface.IIngresoExportRepository, IngresoExportRepository>();
             services.AddScoped<ApplicationInterface.IPresupuestoPdfGenerator, Reporting.PresupuestoPdfGenerator>();
             services.AddScoped<ApplicationInterface.IPresupuestoExcelGenerator, Reporting.PresupuestoExcelGenerator>();
+            services.AddScoped<ApplicationInterface.IGastoExcelGenerator, Reporting.GastoExcelGenerator>();
+            services.AddScoped<ApplicationInterface.IIngresoExcelGenerator, Reporting.IngresoExcelGenerator>();
 
             // 7️⃣ Repositorios Automáticos (Scrutor, vía SergioIzq.Infrastructure.Kernel)
             services.AddKernelRepositories(Assembly.GetExecutingAssembly());

--- a/Kash/Kash.Infrastructure/Persistence/Query/GastoExportRepository.cs
+++ b/Kash/Kash.Infrastructure/Persistence/Query/GastoExportRepository.cs
@@ -1,0 +1,104 @@
+using Dapper;
+using Kash.Shared.Application.Dtos;
+using SergioIzq.Infrastructure.Kernel.Persistence;
+using ApplicationInterface = Kash.Application.Interfaces;
+
+namespace Kash.Infrastructure.Persistence.Query;
+
+public sealed class GastoExportRepository : ApplicationInterface.IGastoExportRepository
+{
+    private readonly IDbConnectionFactory _dbConnectionFactory;
+
+    // Mismas searchableColumns que GastoReadRepository.ConfigureRepository(), para que el
+    // texto de búsqueda de la exportación encuentre lo mismo que el buscador del listado.
+    private static readonly string[] SearchableColumns = ["g.descripcion", "c.nombre", "cat.nombre", "prov.nombre", "p.nombre", "cta.nombre"];
+
+    public GastoExportRepository(IDbConnectionFactory dbConnectionFactory)
+    {
+        _dbConnectionFactory = dbConnectionFactory;
+    }
+
+    public async Task<IReadOnlyList<GastoDto>> GetForExportAsync(
+        Guid usuarioId,
+        ApplicationInterface.GastoExportFiltro filtro,
+        CancellationToken cancellationToken = default)
+    {
+        using var connection = _dbConnectionFactory.CreateConnection();
+
+        var where = new List<string> { "g.id_usuario = @UsuarioId" };
+        var parametros = new DynamicParameters();
+        parametros.Add("UsuarioId", usuarioId);
+
+        if (filtro.FechaInicio.HasValue && filtro.FechaFin.HasValue)
+        {
+            where.Add("g.fecha BETWEEN @FechaInicio AND @FechaFin");
+            parametros.Add("FechaInicio", filtro.FechaInicio.Value);
+            parametros.Add("FechaFin", filtro.FechaFin.Value);
+        }
+
+        if (filtro.ConceptoIds is { Length: > 0 })
+        {
+            where.Add("g.id_concepto IN @ConceptoIds");
+            parametros.Add("ConceptoIds", filtro.ConceptoIds);
+        }
+
+        if (filtro.CategoriaIds is { Length: > 0 })
+        {
+            where.Add("c.id_categoria IN @CategoriaIds");
+            parametros.Add("CategoriaIds", filtro.CategoriaIds);
+        }
+
+        if (filtro.ProveedorIds is { Length: > 0 })
+        {
+            where.Add("g.id_proveedor IN @ProveedorIds");
+            parametros.Add("ProveedorIds", filtro.ProveedorIds);
+        }
+
+        if (filtro.PersonaIds is { Length: > 0 })
+        {
+            where.Add("g.id_persona IN @PersonaIds");
+            parametros.Add("PersonaIds", filtro.PersonaIds);
+        }
+
+        if (!string.IsNullOrWhiteSpace(filtro.SearchTerm))
+        {
+            var busqueda = string.Join(" OR ", SearchableColumns.Select(columna => $"{columna} LIKE @SearchTerm"));
+            where.Add($"({busqueda})");
+            parametros.Add("SearchTerm", $"%{filtro.SearchTerm}%");
+        }
+
+        var sql = $@"
+            SELECT
+                g.id as Id,
+                g.importe as Importe,
+                g.fecha as Fecha,
+                g.descripcion as Descripcion,
+                g.id_concepto as ConceptoId,
+                COALESCE(c.nombre, '') as ConceptoNombre,
+                c.id_categoria as CategoriaId,
+                cat.nombre as CategoriaNombre,
+                g.id_proveedor as ProveedorId,
+                prov.nombre as ProveedorNombre,
+                g.id_persona as PersonaId,
+                p.nombre as PersonaNombre,
+                g.id_cuenta as CuentaId,
+                COALESCE(cta.nombre, '') as CuentaNombre,
+                g.id_forma_pago as FormaPagoId,
+                COALESCE(fp.nombre, '') as FormaPagoNombre,
+                g.id_usuario as UsuarioId
+            FROM gastos g
+            LEFT JOIN conceptos c ON g.id_concepto = c.id
+            LEFT JOIN categorias cat ON c.id_categoria = cat.id
+            LEFT JOIN proveedores prov ON g.id_proveedor = prov.id
+            LEFT JOIN personas p ON g.id_persona = p.id
+            LEFT JOIN cuentas cta ON g.id_cuenta = cta.id
+            LEFT JOIN formas_pago fp ON g.id_forma_pago = fp.id
+            WHERE {string.Join(" AND ", where)}
+            ORDER BY g.fecha DESC, g.id DESC";
+
+        var resultados = await connection.QueryAsync<GastoDto>(
+            new CommandDefinition(sql, parametros, cancellationToken: cancellationToken));
+
+        return resultados.ToList();
+    }
+}

--- a/Kash/Kash.Infrastructure/Persistence/Query/IngresoExportRepository.cs
+++ b/Kash/Kash.Infrastructure/Persistence/Query/IngresoExportRepository.cs
@@ -1,0 +1,104 @@
+using Dapper;
+using Kash.Shared.Application.Dtos;
+using SergioIzq.Infrastructure.Kernel.Persistence;
+using ApplicationInterface = Kash.Application.Interfaces;
+
+namespace Kash.Infrastructure.Persistence.Query;
+
+public sealed class IngresoExportRepository : ApplicationInterface.IIngresoExportRepository
+{
+    private readonly IDbConnectionFactory _dbConnectionFactory;
+
+    // Mismas searchableColumns que IngresoReadRepository.ConfigureRepository(), para que el
+    // texto de búsqueda de la exportación encuentre lo mismo que el buscador del listado.
+    private static readonly string[] SearchableColumns = ["i.descripcion", "c.nombre", "cat.nombre", "cli.nombre", "p.nombre", "cta.nombre"];
+
+    public IngresoExportRepository(IDbConnectionFactory dbConnectionFactory)
+    {
+        _dbConnectionFactory = dbConnectionFactory;
+    }
+
+    public async Task<IReadOnlyList<IngresoDto>> GetForExportAsync(
+        Guid usuarioId,
+        ApplicationInterface.IngresoExportFiltro filtro,
+        CancellationToken cancellationToken = default)
+    {
+        using var connection = _dbConnectionFactory.CreateConnection();
+
+        var where = new List<string> { "i.id_usuario = @UsuarioId" };
+        var parametros = new DynamicParameters();
+        parametros.Add("UsuarioId", usuarioId);
+
+        if (filtro.FechaInicio.HasValue && filtro.FechaFin.HasValue)
+        {
+            where.Add("i.fecha BETWEEN @FechaInicio AND @FechaFin");
+            parametros.Add("FechaInicio", filtro.FechaInicio.Value);
+            parametros.Add("FechaFin", filtro.FechaFin.Value);
+        }
+
+        if (filtro.ConceptoIds is { Length: > 0 })
+        {
+            where.Add("i.id_concepto IN @ConceptoIds");
+            parametros.Add("ConceptoIds", filtro.ConceptoIds);
+        }
+
+        if (filtro.CategoriaIds is { Length: > 0 })
+        {
+            where.Add("c.id_categoria IN @CategoriaIds");
+            parametros.Add("CategoriaIds", filtro.CategoriaIds);
+        }
+
+        if (filtro.ClienteIds is { Length: > 0 })
+        {
+            where.Add("i.id_cliente IN @ClienteIds");
+            parametros.Add("ClienteIds", filtro.ClienteIds);
+        }
+
+        if (filtro.PersonaIds is { Length: > 0 })
+        {
+            where.Add("i.id_persona IN @PersonaIds");
+            parametros.Add("PersonaIds", filtro.PersonaIds);
+        }
+
+        if (!string.IsNullOrWhiteSpace(filtro.SearchTerm))
+        {
+            var busqueda = string.Join(" OR ", SearchableColumns.Select(columna => $"{columna} LIKE @SearchTerm"));
+            where.Add($"({busqueda})");
+            parametros.Add("SearchTerm", $"%{filtro.SearchTerm}%");
+        }
+
+        var sql = $@"
+            SELECT
+                i.id as Id,
+                i.importe as Importe,
+                i.fecha as Fecha,
+                i.descripcion as Descripcion,
+                i.id_concepto as ConceptoId,
+                COALESCE(c.nombre, '') as ConceptoNombre,
+                cat.id as CategoriaId,
+                cat.nombre as CategoriaNombre,
+                i.id_cliente as ClienteId,
+                COALESCE(cli.nombre, '') as ClienteNombre,
+                i.id_persona as PersonaId,
+                COALESCE(p.nombre, '') as PersonaNombre,
+                i.id_cuenta as CuentaId,
+                COALESCE(cta.nombre, '') as CuentaNombre,
+                i.id_forma_pago as FormaPagoId,
+                COALESCE(fp.nombre, '') as FormaPagoNombre,
+                i.id_usuario as UsuarioId
+            FROM ingresos i
+            LEFT JOIN conceptos c ON i.id_concepto = c.id
+            LEFT JOIN categorias cat ON c.id_categoria = cat.id
+            LEFT JOIN clientes cli ON i.id_cliente = cli.id
+            LEFT JOIN personas p ON i.id_persona = p.id
+            LEFT JOIN cuentas cta ON i.id_cuenta = cta.id
+            LEFT JOIN formas_pago fp ON i.id_forma_pago = fp.id
+            WHERE {string.Join(" AND ", where)}
+            ORDER BY i.fecha DESC, i.id DESC";
+
+        var resultados = await connection.QueryAsync<IngresoDto>(
+            new CommandDefinition(sql, parametros, cancellationToken: cancellationToken));
+
+        return resultados.ToList();
+    }
+}

--- a/Kash/Kash.Infrastructure/Reporting/GastoExcelGenerator.cs
+++ b/Kash/Kash.Infrastructure/Reporting/GastoExcelGenerator.cs
@@ -1,0 +1,84 @@
+using ClosedXML.Excel;
+using Kash.Application.Interfaces;
+using Kash.Shared.Application.Dtos;
+
+namespace Kash.Infrastructure.Reporting;
+
+/// <summary>
+/// Genera un Excel de detalle (una fila por Gasto) con ClosedXML, mismo esquema visual que
+/// <see cref="PresupuestoExcelGenerator"/>.
+/// </summary>
+public sealed class GastoExcelGenerator : IGastoExcelGenerator
+{
+    private static readonly XLColor ColorCabeceraTabla = XLColor.FromHtml("#C62828");
+    private static readonly XLColor ColorFilaAlterna = XLColor.FromHtml("#F2F6FC");
+
+    private const string FormatoMoneda = "#,##0.00 €";
+    private const string FormatoFecha = "dd/mm/yyyy";
+
+    public byte[] Generar(IReadOnlyList<GastoDto> datos)
+    {
+        using var libro = new XLWorkbook();
+        var ws = libro.Worksheets.Add("Gastos");
+        ws.ShowGridLines = false;
+
+        var headers = new[] { "Fecha", "Concepto", "Categoría", "Proveedor", "Persona", "Cuenta", "Forma de Pago", "Importe", "Descripción" };
+        EscribirCabeceraTabla(ws, headers);
+
+        var fila = 2;
+        foreach (var gasto in datos)
+        {
+            ws.Cell(fila, 1).Value = gasto.Fecha;
+            ws.Cell(fila, 1).Style.DateFormat.Format = FormatoFecha;
+            ws.Cell(fila, 2).Value = gasto.ConceptoNombre;
+            ws.Cell(fila, 3).Value = gasto.CategoriaNombre ?? string.Empty;
+            ws.Cell(fila, 4).Value = gasto.ProveedorNombre;
+            ws.Cell(fila, 5).Value = gasto.PersonaNombre;
+            ws.Cell(fila, 6).Value = gasto.CuentaNombre;
+            ws.Cell(fila, 7).Value = gasto.FormaPagoNombre;
+            ws.Cell(fila, 8).Value = gasto.Importe;
+            ws.Cell(fila, 9).Value = gasto.Descripcion ?? string.Empty;
+            fila++;
+        }
+
+        if (fila > 2)
+        {
+            var rango = ws.Range(1, 1, fila - 1, headers.Length);
+            EstilizarTabla(rango, 2, fila - 1, columnasMoneda: [8]);
+        }
+
+        ws.SheetView.Freeze(1, 0);
+        ws.Columns(1, headers.Length).AdjustToContents();
+
+        using var memoria = new MemoryStream();
+        libro.SaveAs(memoria);
+        return memoria.ToArray();
+    }
+
+    private static void EscribirCabeceraTabla(IXLWorksheet ws, string[] headers)
+    {
+        for (var i = 0; i < headers.Length; i++)
+            ws.Cell(1, i + 1).Value = headers[i];
+
+        var rango = ws.Range(1, 1, 1, headers.Length);
+        rango.Style.Font.SetBold().Font.SetFontColor(XLColor.White)
+            .Fill.SetBackgroundColor(ColorCabeceraTabla)
+            .Alignment.SetVertical(XLAlignmentVerticalValues.Center);
+        ws.Row(1).Height = 20;
+    }
+
+    private static void EstilizarTabla(IXLRange rango, int filaDatosInicio, int filaDatosFin, int[] columnasMoneda)
+    {
+        rango.Style.Border.SetOutsideBorder(XLBorderStyleValues.Thin);
+        rango.Style.Border.SetInsideBorder(XLBorderStyleValues.Hair);
+
+        for (var fila = filaDatosInicio; fila <= filaDatosFin; fila++)
+        {
+            if ((fila - filaDatosInicio) % 2 == 1)
+                rango.Worksheet.Row(fila).Style.Fill.SetBackgroundColor(ColorFilaAlterna);
+
+            foreach (var col in columnasMoneda)
+                rango.Worksheet.Cell(fila, col).Style.NumberFormat.Format = FormatoMoneda;
+        }
+    }
+}

--- a/Kash/Kash.Infrastructure/Reporting/IngresoExcelGenerator.cs
+++ b/Kash/Kash.Infrastructure/Reporting/IngresoExcelGenerator.cs
@@ -1,0 +1,84 @@
+using ClosedXML.Excel;
+using Kash.Application.Interfaces;
+using Kash.Shared.Application.Dtos;
+
+namespace Kash.Infrastructure.Reporting;
+
+/// <summary>
+/// Genera un Excel de detalle (una fila por Ingreso) con ClosedXML, mismo esquema visual que
+/// <see cref="PresupuestoExcelGenerator"/>.
+/// </summary>
+public sealed class IngresoExcelGenerator : IIngresoExcelGenerator
+{
+    private static readonly XLColor ColorCabeceraTabla = XLColor.FromHtml("#2E7D32");
+    private static readonly XLColor ColorFilaAlterna = XLColor.FromHtml("#F2F6FC");
+
+    private const string FormatoMoneda = "#,##0.00 €";
+    private const string FormatoFecha = "dd/mm/yyyy";
+
+    public byte[] Generar(IReadOnlyList<IngresoDto> datos)
+    {
+        using var libro = new XLWorkbook();
+        var ws = libro.Worksheets.Add("Ingresos");
+        ws.ShowGridLines = false;
+
+        var headers = new[] { "Fecha", "Concepto", "Categoría", "Cliente", "Persona", "Cuenta", "Forma de Pago", "Importe", "Descripción" };
+        EscribirCabeceraTabla(ws, headers);
+
+        var fila = 2;
+        foreach (var ingreso in datos)
+        {
+            ws.Cell(fila, 1).Value = ingreso.Fecha;
+            ws.Cell(fila, 1).Style.DateFormat.Format = FormatoFecha;
+            ws.Cell(fila, 2).Value = ingreso.ConceptoNombre;
+            ws.Cell(fila, 3).Value = ingreso.CategoriaNombre ?? string.Empty;
+            ws.Cell(fila, 4).Value = ingreso.ClienteNombre ?? string.Empty;
+            ws.Cell(fila, 5).Value = ingreso.PersonaNombre ?? string.Empty;
+            ws.Cell(fila, 6).Value = ingreso.CuentaNombre;
+            ws.Cell(fila, 7).Value = ingreso.FormaPagoNombre;
+            ws.Cell(fila, 8).Value = ingreso.Importe;
+            ws.Cell(fila, 9).Value = ingreso.Descripcion ?? string.Empty;
+            fila++;
+        }
+
+        if (fila > 2)
+        {
+            var rango = ws.Range(1, 1, fila - 1, headers.Length);
+            EstilizarTabla(rango, 2, fila - 1, columnasMoneda: [8]);
+        }
+
+        ws.SheetView.Freeze(1, 0);
+        ws.Columns(1, headers.Length).AdjustToContents();
+
+        using var memoria = new MemoryStream();
+        libro.SaveAs(memoria);
+        return memoria.ToArray();
+    }
+
+    private static void EscribirCabeceraTabla(IXLWorksheet ws, string[] headers)
+    {
+        for (var i = 0; i < headers.Length; i++)
+            ws.Cell(1, i + 1).Value = headers[i];
+
+        var rango = ws.Range(1, 1, 1, headers.Length);
+        rango.Style.Font.SetBold().Font.SetFontColor(XLColor.White)
+            .Fill.SetBackgroundColor(ColorCabeceraTabla)
+            .Alignment.SetVertical(XLAlignmentVerticalValues.Center);
+        ws.Row(1).Height = 20;
+    }
+
+    private static void EstilizarTabla(IXLRange rango, int filaDatosInicio, int filaDatosFin, int[] columnasMoneda)
+    {
+        rango.Style.Border.SetOutsideBorder(XLBorderStyleValues.Thin);
+        rango.Style.Border.SetInsideBorder(XLBorderStyleValues.Hair);
+
+        for (var fila = filaDatosInicio; fila <= filaDatosFin; fila++)
+        {
+            if ((fila - filaDatosInicio) % 2 == 1)
+                rango.Worksheet.Row(fila).Style.Fill.SetBackgroundColor(ColorFilaAlterna);
+
+            foreach (var col in columnasMoneda)
+                rango.Worksheet.Cell(fila, col).Style.NumberFormat.Format = FormatoMoneda;
+        }
+    }
+}

--- a/openspec/changes/archive/2026-08-21-exportacion-excel-gastos-ingresos/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-21-exportacion-excel-gastos-ingresos/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/archive/2026-08-21-exportacion-excel-gastos-ingresos/design.md
+++ b/openspec/changes/archive/2026-08-21-exportacion-excel-gastos-ingresos/design.md
@@ -1,0 +1,47 @@
+## Context
+
+Ver `proposal.md - Why` para la motivación (consumidor: `Kash-Frontend`, change `dialogo-exportar-excel-gastos-ingresos`). Puntos de partida verificados en este repo:
+
+- `GastoReadRepository`/`IngresoReadRepository` (`Kash.Infrastructure/Persistence/Data/`) ya definen, vía `ReadRepositoryConfiguration.WithJoins(...)`, las columnas/joins/`searchableColumns` que usa hoy el listado paginado: alias `g`/`i`, joins a `conceptos`→`categorias`, `proveedores`/`clientes`, `personas`, `cuentas`, `formas_pago`; `searchableColumns` = descripción + nombre de concepto/categoría/proveedor-cliente/persona/cuenta. El filtro de texto de la exportación debe buscar en las mismas columnas para que el resultado sea coherente con lo que el usuario ve al escribir en el buscador del listado.
+- El paginado genérico del kernel (`GetPagedReadModelsByUserAsync`) no acepta filtros extra — mismo motivo ya documentado en la propuesta archivada `conceptos-paginados-por-categoria` — así que un `WHERE` multi-filtro (fecha + varios conceptos + varias categorías + varios terceros + varias personas, todo combinable) tampoco puede montarse sobre ese método.
+- Ya existe en este repo un patrón completo y más simple que el paginado genérico para "generar y descargar un Excel": `GetPresupuestoExcelQuery`/`GetPresupuestoExcelQueryHandler` (`Features/Reportes/Queries/GetPresupuestoExcel/`), que **no** hereda de la infraestructura de listado paginado — es un `IQuery<TResult>`/`IQueryHandler` normal (patrón CQRS del kernel de mensajería, no el de listados) que: valida la petición, pide los datos ya filtrados a un repositorio, genera el `.xlsx` con `IPresupuestoExcelGenerator` (ClosedXML) y devuelve `Result.Success(new PresupuestoArchivoDto(nombre, excel))`. `ReportesController` lo sirve con `File(result.Value.Contenido, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", result.Value.NombreArchivo)`. Este es el patrón a replicar, no el de `GetPagedListQueryHandler`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Exportar a Excel el conjunto completo (sin paginar) de Gastos o Ingresos del usuario que cumple los filtros indicados.
+- Soportar filtros combinables: rango de fechas, Concepto(s), Categoría(s), Proveedor(es)/Cliente(s), Persona(s), texto de búsqueda — todos opcionales, combinados en AND entre filtros distintos y en OR dentro de un mismo filtro multi-valor.
+- Mantener el aislamiento por usuario ya garantizado en el resto de endpoints.
+
+**Non-Goals:**
+- No se toca el listado paginado existente (`GET /gastos`, `GET /ingresos`) ni su contrato.
+- No se añade exportación a Excel para Inversiones ni para ningún otro catálogo (fuera de alcance, ver `proposal.md`).
+- No se generaliza `GetPagedListQueryHandler` ni el kernel compartido con un hook de filtros — se resuelve de forma local a Gastos/Ingresos, mismo criterio que `conceptos-paginados-por-categoria`.
+- No se pagina la respuesta ni se limita el número de filas del Excel (si el usuario no filtra, exporta todo su histórico).
+
+## Decisions
+
+**1. Se replica el patrón de `GetPresupuestoExcelQuery` (CQRS simple), no el de `GetPagedListQueryHandler`.**
+`GetGastosExcelQuery(UsuarioId, FechaInicio?, FechaFin?, SearchTerm?, ConceptoIds?, CategoriaIds?, ProveedorIds?, PersonaIds?) : IQuery<GastoExcelArchivoDto>` (e `GetIngresosExcelQuery` equivalente, con `ClienteIds` en vez de `ProveedorIds`). El handler pide al repositorio nuevo la lista completa de `GastoDto`/`IngresoDto` que cumple los filtros, genera el Excel y devuelve `(NombreArchivo, Contenido)`, igual que `PresupuestoArchivoDto`.
+*Alternativa descartada*: extender `GetGastosPagedListQuery`/su handler para que, con un parámetro `formato=excel`, devuelva Excel en vez de JSON paginado — mezclaría dos responsabilidades muy distintas (listar paginado vs. exportar completo) en el mismo endpoint y query, y complicaría el contrato HTTP existente sin necesidad.
+
+**2. Nuevo repositorio Dapper por catálogo (`IGastoExportRepository`/`IIngresoExportRepository`), reutilizando las mismas columnas/joins que `GastoReadRepository`/`IngresoReadRepository`.**
+Igual que `ConceptoPaginadoRepository` de la propuesta ya archivada: interfaz en `Kash.Application/Interfaces/`, implementación Dapper en `Kash.Infrastructure/Persistence/Query/`, registrada manualmente en DI (no vía el escaneo automático de Scrutor, que cubre las interfaces marcador de Domain). El método (`GetForExportAsync(usuarioId, filtro, ct)`) arma el `WHERE` dinámicamente: siempre `id_usuario = @UsuarioId`; añade `fecha BETWEEN @FechaInicio AND @FechaFin` si hay rango; `id_concepto IN @ConceptoIds` si hay conceptos; `id_categoria IN @CategoriaIds` (sobre la categoría del concepto, vía el join ya existente) si hay categorías; `id_proveedor IN @ProveedorIds` (`id_cliente IN @ClienteIds` en Ingresos) si hay terceros; `id_persona IN @PersonaIds` si hay personas; y una condición `OR` sobre las mismas `searchableColumns` que ya usa el listado paginado si hay `searchTerm`. Sin `LIMIT`/`OFFSET` ni consulta de conteo — devuelve todo lo que matchea.
+*Alternativa descartada*: construir el filtro con Entity Framework (LINQ dinámico) en vez de Dapper — el resto de repositorios de lectura de este proyecto ya usan Dapper de forma consistente (rendimiento, control total del SQL); introducir EF aquí rompería ese patrón sin aportar nada.
+
+**3. `GastoExcelGenerator`/`IngresoExcelGenerator` (ClosedXML), mismo patrón visual que `PresupuestoExcelGenerator`.**
+Una sola hoja con cabecera de columnas (Fecha, Concepto, Categoría, Proveedor/Cliente, Persona, Cuenta, Forma de Pago, Importe, Descripción), formato de fecha/moneda igual que el generador de Presupuesto (`dd/mm/yyyy`, `#,##0.00 €`), fila de cabecera con estilo. No hace falta ninguna hoja de resumen/KPIs (a diferencia de Presupuesto) porque esto es una exportación de detalle, no un informe agregado.
+
+**4. Los filtros de catálogo (`ConceptoIds`, `CategoriaIds`, `ProveedorIds`/`ClienteIds`, `PersonaIds`) se validan solo por pertenencia implícita al `WHERE id_usuario`, no con una consulta previa de existencia.**
+Si el frontend envía un id de catálogo que no pertenece al usuario (o no existe), el `WHERE id_usuario = @UsuarioId AND id_concepto IN (...)` simplemente no encuentra filas para ese filtro — mismo comportamiento (y mismo riesgo aceptado) que ya se documentó y verificó para `categoriaId` en Conceptos. No se añade una validación de existencia adicional que ya cubre implícitamente el filtro por usuario.
+*Alternativa descartada*: devolver un error 400 si algún id de catálogo no existe o no pertenece al usuario — más estricto, pero requeriría una consulta extra por cada catálogo filtrado solo para dar un mensaje de error más específico ante un caso (ids inválidos enviados por el propio cliente) que ya se comporta de forma segura sin esa validación.
+
+## Risks / Trade-offs
+
+- **[Riesgo] Exportaciones sin ningún filtro sobre un historial muy grande pueden generar un Excel pesado y tardar.** Aceptado por ahora: no hay límite de filas en el alcance de este cambio (ver Non-Goals); si en producción resulta un problema real, se puede añadir un límite o una exportación asíncrona en un cambio posterior.
+- **[Riesgo] `WHERE ... IN @Lista` con listas vacías.** Mitigación: el repositorio solo añade la condición `IN` al `WHERE` cuando la lista de ids correspondiente tiene al menos un elemento; una lista vacía o no informada no añade ninguna restricción para ese filtro (equivale a "no filtrar por esto"), evitando el error de SQL de un `IN ()` vacío.
+- **[Riesgo] Dos repositorios de exportación casi idénticos (Gastos/Ingresos) en vez de uno genérico.** Aceptado: mismo criterio que el resto del código de Kash (`GastoReadRepository`/`IngresoReadRepository` ya están duplicados por catálogo); generalizar ahora sería especular con una abstracción que no se ha necesitado hasta hoy.
+
+## Migration Plan
+
+No aplica migración de datos. Cambio aditivo: dos endpoints nuevos (`GET /gastos/excel`, `GET /ingresos/excel`); no se modifica ningún endpoint existente. Sin rollback especial más allá de revertir el despliegue si hiciera falta.

--- a/openspec/changes/archive/2026-08-21-exportacion-excel-gastos-ingresos/proposal.md
+++ b/openspec/changes/archive/2026-08-21-exportacion-excel-gastos-ingresos/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+El botón "Exportar" de Gastos e Ingresos genera hoy un CSV en el propio navegador a partir de los datos ya cargados en la tabla — como las tablas son paginadas en servidor (10-30 filas), en la práctica solo se exporta la página visible, nunca el histórico completo, y no hay forma de acotar la exportación por fecha, concepto, categoría o tercero. El frontend (`Kash-Frontend`, change `dialogo-exportar-excel-gastos-ingresos`) quiere ofrecer un diálogo de exportación con filtros combinables (rango de fechas, concepto, categoría, proveedor/cliente, persona, o la búsqueda actual de la tabla) que descargue un Excel real generado en el backend con el conjunto completo de resultados que cumpla esos filtros.
+
+## What Changes
+
+- Nuevos endpoints `GET /api/gastos/excel` y `GET /api/ingresos/excel` que aceptan filtros opcionales y combinables: `searchTerm`, `fechaInicio`/`fechaFin`, `conceptoIds` (lista), `categoriaIds` (lista), `proveedorIds`/`clienteIds` (lista), `personaIds` (lista). Los filtros se combinan en AND entre sí; dentro de una misma lista (p. ej. varios `conceptoIds`), en OR. Sin ningún filtro informado, exporta todo el histórico del usuario.
+- Los resultados no se paginan: se exporta el conjunto completo que cumple los filtros, no una página.
+- El archivo devuelto es un libro Excel (.xlsx) real (no CSV), con más columnas que el CSV actual: Fecha, Concepto, Categoría, Proveedor/Cliente, Persona, Cuenta, Forma de Pago, Importe y Descripción.
+- Reutiliza el patrón ya existente en `Kash-Backend` para generar Excel (`PresupuestoExcelGenerator` con ClosedXML, servido como `File(...)` desde un controller).
+
+## Capabilities
+
+### New Capabilities
+- `exportacion-excel-gastos-ingresos`: exportación a Excel de Gastos e Ingresos con filtrado combinable por fecha, concepto, categoría, proveedor/cliente, persona y búsqueda de texto.
+
+### Modified Capabilities
+(ninguna — no hay spec previa que capture el comportamiento de exportación de Gastos/Ingresos)
+
+## Impact
+
+- **`Kash.Api`**: `GastosController` gana `GET /gastos/excel`; `IngresosController` gana `GET /ingresos/excel`.
+- **`Kash.Application`**: nuevas queries `GetGastosExcelQuery`/`GetIngresosExcelQuery` (sin paginación) con sus handlers; nuevas interfaces `IGastoExportRepository`/`IIngresoExportRepository` en `Interfaces/` (mismo motivo que `IConceptoPaginadoRepository`: el paginado genérico del kernel no admite un `WHERE` multi-filtro).
+- **`Kash.Infrastructure`**: nuevos repositorios Dapper `GastoExportRepository`/`IngresoExportRepository` (`Persistence/Query/`) que arman el `WHERE` dinámico según los filtros informados; nuevos `GastoExcelGenerator`/`IngresoExcelGenerator` (`Reporting/`, ClosedXML, mismo patrón que `PresupuestoExcelGenerator`); registro en DI.
+- **Consumidor externo**: `Kash-Frontend`, change `dialogo-exportar-excel-gastos-ingresos` (repo separado, sin acoplamiento de código — solo de contrato HTTP).
+- Sin cambios breaking: el botón "Exportar" actual (CSV client-side) se sustituye en el frontend, pero eso es alcance de ese otro change; este cambio solo añade endpoints nuevos.

--- a/openspec/changes/archive/2026-08-21-exportacion-excel-gastos-ingresos/specs/exportacion-excel-gastos-ingresos/spec.md
+++ b/openspec/changes/archive/2026-08-21-exportacion-excel-gastos-ingresos/specs/exportacion-excel-gastos-ingresos/spec.md
@@ -1,0 +1,46 @@
+## Purpose
+
+Permitir exportar a un libro Excel el listado de Gastos o de Ingresos del usuario autenticado, con filtros combinables por fecha, concepto, categoría, proveedor/cliente, persona y búsqueda de texto, devolviendo siempre el conjunto completo de resultados que cumple los filtros (sin paginar).
+
+## ADDED Requirements
+
+### Requirement: Exportación a Excel del listado completo de Gastos o Ingresos
+El sistema SHALL permitir al usuario autenticado descargar un libro Excel (.xlsx) con sus Gastos, o alternativamente con sus Ingresos, incluyendo Fecha, Concepto, Categoría, Proveedor o Cliente (según corresponda), Persona, Cuenta, Forma de Pago, Importe y Descripción de cada registro.
+
+#### Scenario: Exportar sin ningún filtro
+- **WHEN** el usuario autenticado solicita la exportación a Excel de sus Gastos (o Ingresos) sin indicar ningún filtro
+- **THEN** el sistema devuelve un libro Excel con todos los Gastos (o Ingresos) del usuario, sin límite de página
+
+#### Scenario: El resultado no está paginado
+- **WHEN** el usuario autenticado solicita la exportación y el conjunto de resultados es mayor que el tamaño de página usado en el listado habitual
+- **THEN** el sistema incluye en el Excel la totalidad de los resultados que cumplen los filtros, no solo una página
+
+### Requirement: Filtrado combinable de la exportación
+El sistema SHALL aceptar, en la exportación a Excel, filtros opcionales por rango de fechas, uno o varios Conceptos, una o varias Categorías, uno o varios Proveedores (Gastos) o Clientes (Ingresos), una o varias Personas, y un texto de búsqueda equivalente al usado en el listado paginado. Los filtros informados SHALL combinarse entre sí en conjunción (deben cumplirse todos los filtros activos); dentro de un mismo filtro con varios valores (p. ej. varios Conceptos), SHALL bastar con que se cumpla al menos uno de esos valores.
+
+#### Scenario: Filtro por rango de fechas
+- **WHEN** el usuario solicita la exportación indicando una fecha de inicio y una fecha de fin
+- **THEN** el sistema incluye únicamente los registros cuya fecha está dentro de ese rango (ambos extremos incluidos)
+
+#### Scenario: Filtro con varios valores del mismo tipo
+- **WHEN** el usuario solicita la exportación indicando más de un Concepto (o más de una Categoría, Proveedor/Cliente, o Persona)
+- **THEN** el sistema incluye los registros que coinciden con cualquiera de los valores indicados para ese filtro
+
+#### Scenario: Combinación de filtros de distinto tipo
+- **WHEN** el usuario solicita la exportación indicando a la vez, por ejemplo, un rango de fechas y una o varias Categorías
+- **THEN** el sistema incluye únicamente los registros que cumplen el rango de fechas Y pertenecen a alguna de las Categorías indicadas
+
+#### Scenario: Filtro por búsqueda de texto
+- **WHEN** el usuario solicita la exportación indicando un texto de búsqueda
+- **THEN** el sistema incluye únicamente los registros que ese mismo texto encontraría en el listado paginado habitual
+
+#### Scenario: Filtros sin resultados
+- **WHEN** los filtros indicados no coinciden con ningún registro del usuario
+- **THEN** el sistema devuelve un libro Excel válido sin filas de datos, sin error
+
+### Requirement: Aislamiento entre usuarios en la exportación
+El sistema SHALL restringir siempre la exportación a los Gastos o Ingresos del usuario autenticado, sin exponer registros de otros usuarios aunque los filtros (p. ej. un `conceptoId` o `categoriaId`) coincidan con catálogo de otro usuario.
+
+#### Scenario: Filtro con un identificador de catálogo de otro usuario
+- **WHEN** el usuario autenticado solicita la exportación filtrando por un Concepto, Categoría, Proveedor/Cliente o Persona que pertenece a otro usuario
+- **THEN** el sistema no incluye registros de ese otro usuario; se comporta igual que si ese filtro no tuviera ningún resultado propio

--- a/openspec/changes/archive/2026-08-21-exportacion-excel-gastos-ingresos/tasks.md
+++ b/openspec/changes/archive/2026-08-21-exportacion-excel-gastos-ingresos/tasks.md
@@ -1,0 +1,34 @@
+## 1. Contrato de las queries y endpoints
+
+- [x] 1.1 Creada `GetGastosExcelQuery(Guid UsuarioId, DateTime? FechaInicio, DateTime? FechaFin, string? SearchTerm, Guid[]? ConceptoIds, Guid[]? CategoriaIds, Guid[]? ProveedorIds, Guid[]? PersonaIds) : IQuery<PresupuestoArchivoDto>`, mismo patrón que `GetPresupuestoExcelQuery`
+- [x] 1.2 Creada `GetIngresosExcelQuery` equivalente, con `Guid[]? ClienteIds` en vez de `ProveedorIds`
+- [x] 1.3 **[Reutilizado]** `PresupuestoArchivoDto` (`NombreArchivo`, `Contenido`) ya tiene la forma exacta necesaria — no se crea un DTO nuevo, ambas queries devuelven ese mismo tipo
+- [x] 1.4 Añadido `GET /gastos/excel` a `GastosController` con `[FromQuery] DateTime? fechaInicio, DateTime? fechaFin, string? searchTerm, Guid[]? conceptoIds, Guid[]? categoriaIds, Guid[]? proveedorIds, Guid[]? personaIds`, devolviendo `File(...)` con mime `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`
+- [x] 1.5 Añadido `GET /ingresos/excel` a `IngresosController` equivalente, con `clienteIds` en vez de `proveedorIds`
+
+## 2. Repositorios de exportación (sin paginar, WHERE dinámico)
+
+- [x] 2.1 Creada `IGastoExportRepository` en `Kash.Application/Interfaces/` (junto con el record `GastoExportFiltro`) con `GetForExportAsync(Guid usuarioId, GastoExportFiltro filtro, CancellationToken ct)` devolviendo `IReadOnlyList<GastoDto>`
+- [x] 2.2 Implementado `GastoExportRepository` en `Kash.Infrastructure/Persistence/Query/` con Dapper: mismas columnas/joins que `GastoReadRepository.ConfigureRepository()`, `WHERE g.id_usuario = @UsuarioId` siempre, más `AND g.fecha BETWEEN @FechaInicio AND @FechaFin` si hay rango, `AND g.id_concepto IN @ConceptoIds` si la lista no está vacía, `AND c.id_categoria IN @CategoriaIds` si no está vacía, `AND g.id_proveedor IN @ProveedorIds` si no está vacía, `AND g.id_persona IN @PersonaIds` si no está vacía, y `AND (searchable OR ...)` sobre las mismas `searchableColumns` que `GastoReadRepository` si hay `searchTerm`; sin `LIMIT`/`OFFSET`
+- [x] 2.3 Creadas `IIngresoExportRepository`/`IngresoExportRepository` equivalentes, con `id_cliente` en vez de `id_proveedor`, mismas columnas/joins que `IngresoReadRepository.ConfigureRepository()`
+- [x] 2.4 Registrados ambos repositorios en DI (`Kash.Infrastructure/DependencyInjection.cs`)
+- [x] 2.5 Verificado contra `AhorroLandTest` (BD de test) con un usuario real: filtro por concepto, categoría, proveedor, cliente, rango de fechas y texto de búsqueda cada uno por separado, y una combinación concepto+proveedor, comparando siempre contra un `COUNT(*)` SQL directo independiente. Todos coinciden; el único resultado inicialmente sorprendente (búsqueda por texto "Peluquería" trayendo un Gasto de concepto "VPS") resultó ser correcto: ese Gasto tiene como Proveedor "Peluquería Kbello", y la búsqueda coincide en `prov.nombre` igual que hace el listado paginado — confirma que el `OR` entre `searchableColumns` funciona como se diseñó, no un fallo
+
+## 3. Generadores de Excel (ClosedXML)
+
+- [x] 3.1 Creadas `IGastoExcelGenerator`/`IIngresoExcelGenerator` en `Kash.Application/Interfaces/` con `byte[] Generar(IReadOnlyList<GastoDto> datos)` (e `IngresoDto` equivalente)
+- [x] 3.2 Implementados `GastoExcelGenerator`/`IngresoExcelGenerator` en `Kash.Infrastructure/Reporting/` con ClosedXML: una hoja, cabecera (Fecha, Concepto, Categoría, Proveedor/Cliente, Persona, Cuenta, Forma de Pago, Importe, Descripción), formato `dd/mm/yyyy` y `#,##0.00 €`, filas alternas y bordes, mismos helpers que `PresupuestoExcelGenerator`
+- [x] 3.3 Registrados ambos generadores en DI
+
+## 4. Handlers
+
+- [x] 4.1 Implementado `GetGastosExcelQueryHandler`: valida `UsuarioId` no vacío y (si hay rango) `FechaInicio <= FechaFin`, llama a `IGastoExportRepository.GetForExportAsync(...)`, genera el Excel con `IGastoExcelGenerator`, devuelve `Result.Success(new PresupuestoArchivoDto(nombre, excel))` con nombre `gastos_{yyyyMMdd}.xlsx` (fecha de generación, UTC)
+- [x] 4.2 Implementado `GetIngresosExcelQueryHandler` equivalente, nombre `ingresos_{yyyyMMdd}.xlsx`
+
+## 5. Aislamiento y validación final
+
+- [x] 5.1 Verificado con datos reales: un `conceptoId` que sí pertenece a un usuario, pedido con un `usuarioId` distinto (aleatorio), devuelve 0 resultados tanto en Gastos como en Ingresos — el filtro `id_usuario` sigue aplicándose siempre, incluso combinado con otros filtros
+- [x] 5.2 Verificado que listas vacías (`[]`, no `null`) en los 4 filtros de catálogo a la vez no rompen la consulta y devuelven el total sin restringir (mismo resultado que sin informar esos filtros); también verificado con un `conceptoId` inexistente (GUID aleatorio), que da 0 resultados sin error
+- [x] 5.3 `dotnet build` de `Kash.Application`/`Kash.Infrastructure` (aislados) y `dotnet build Kash.sln` completo: compilación sin errores ni avisos
+- [x] 5.4 Confirmado contra `Kash-Frontend` (change `dialogo-exportar-excel-gastos-ingresos`, `proposal.md`/`design.md`): los nombres de los query params (`fechaInicio`, `fechaFin`, `searchTerm`, `conceptoIds`, `categoriaIds`, `proveedorIds`/`clienteIds`, `personaIds`) coinciden exactamente con lo que ese cambio espera enviar
+- [x] 5.5 `openspec validate exportacion-excel-gastos-ingresos --strict`: "Change 'exportacion-excel-gastos-ingresos' is valid"

--- a/openspec/specs/exportacion-excel-gastos-ingresos/spec.md
+++ b/openspec/specs/exportacion-excel-gastos-ingresos/spec.md
@@ -1,0 +1,48 @@
+# exportacion-excel-gastos-ingresos Specification
+
+## Purpose
+
+Permitir exportar a un libro Excel el listado de Gastos o de Ingresos del usuario autenticado, con filtros combinables por fecha, concepto, categoría, proveedor/cliente, persona y búsqueda de texto, devolviendo siempre el conjunto completo de resultados que cumple los filtros (sin paginar).
+
+## Requirements
+
+### Requirement: Exportación a Excel del listado completo de Gastos o Ingresos
+El sistema SHALL permitir al usuario autenticado descargar un libro Excel (.xlsx) con sus Gastos, o alternativamente con sus Ingresos, incluyendo Fecha, Concepto, Categoría, Proveedor o Cliente (según corresponda), Persona, Cuenta, Forma de Pago, Importe y Descripción de cada registro.
+
+#### Scenario: Exportar sin ningún filtro
+- **WHEN** el usuario autenticado solicita la exportación a Excel de sus Gastos (o Ingresos) sin indicar ningún filtro
+- **THEN** el sistema devuelve un libro Excel con todos los Gastos (o Ingresos) del usuario, sin límite de página
+
+#### Scenario: El resultado no está paginado
+- **WHEN** el usuario autenticado solicita la exportación y el conjunto de resultados es mayor que el tamaño de página usado en el listado habitual
+- **THEN** el sistema incluye en el Excel la totalidad de los resultados que cumplen los filtros, no solo una página
+
+### Requirement: Filtrado combinable de la exportación
+El sistema SHALL aceptar, en la exportación a Excel, filtros opcionales por rango de fechas, uno o varios Conceptos, una o varias Categorías, uno o varios Proveedores (Gastos) o Clientes (Ingresos), una o varias Personas, y un texto de búsqueda equivalente al usado en el listado paginado. Los filtros informados SHALL combinarse entre sí en conjunción (deben cumplirse todos los filtros activos); dentro de un mismo filtro con varios valores (p. ej. varios Conceptos), SHALL bastar con que se cumpla al menos uno de esos valores.
+
+#### Scenario: Filtro por rango de fechas
+- **WHEN** el usuario solicita la exportación indicando una fecha de inicio y una fecha de fin
+- **THEN** el sistema incluye únicamente los registros cuya fecha está dentro de ese rango (ambos extremos incluidos)
+
+#### Scenario: Filtro con varios valores del mismo tipo
+- **WHEN** el usuario solicita la exportación indicando más de un Concepto (o más de una Categoría, Proveedor/Cliente, o Persona)
+- **THEN** el sistema incluye los registros que coinciden con cualquiera de los valores indicados para ese filtro
+
+#### Scenario: Combinación de filtros de distinto tipo
+- **WHEN** el usuario solicita la exportación indicando a la vez, por ejemplo, un rango de fechas y una o varias Categorías
+- **THEN** el sistema incluye únicamente los registros que cumplen el rango de fechas Y pertenecen a alguna de las Categorías indicadas
+
+#### Scenario: Filtro por búsqueda de texto
+- **WHEN** el usuario solicita la exportación indicando un texto de búsqueda
+- **THEN** el sistema incluye únicamente los registros que ese mismo texto encontraría en el listado paginado habitual
+
+#### Scenario: Filtros sin resultados
+- **WHEN** los filtros indicados no coinciden con ningún registro del usuario
+- **THEN** el sistema devuelve un libro Excel válido sin filas de datos, sin error
+
+### Requirement: Aislamiento entre usuarios en la exportación
+El sistema SHALL restringir siempre la exportación a los Gastos o Ingresos del usuario autenticado, sin exponer registros de otros usuarios aunque los filtros (p. ej. un `conceptoId` o `categoriaId`) coincidan con catálogo de otro usuario.
+
+#### Scenario: Filtro con un identificador de catálogo de otro usuario
+- **WHEN** el usuario autenticado solicita la exportación filtrando por un Concepto, Categoría, Proveedor/Cliente o Persona que pertenece a otro usuario
+- **THEN** el sistema no incluye registros de ese otro usuario; se comporta igual que si ese filtro no tuviera ningún resultado propio


### PR DESCRIPTION
## Motivo de los cambios
El botón "Exportar" de Gastos e Ingresos generaba un CSV en el navegador a partir de
los datos ya cargados en la tabla — como las tablas son paginadas en servidor
(10-30 filas), en la práctica solo se exportaba la página visible, nunca el
histórico completo, y no había forma de acotar la exportación por fecha, concepto,
categoría o tercero. El frontend (`Kash-Frontend`, change
`dialogo-exportar-excel-gastos-ingresos`) quería ofrecer un diálogo de exportación
con filtros combinables que descargue un Excel real generado en el backend con el
conjunto completo de resultados que cumpla esos filtros.

## Descripción de la solución
- Nuevos endpoints `GET /gastos/excel` y `GET /ingresos/excel` con filtros
  opcionales y combinables: rango de fechas, uno o varios Conceptos, Categorías,
  Proveedores/Clientes, Personas, y texto de búsqueda (AND entre filtros, OR
  dentro de un mismo filtro multivalor). Sin ningún filtro, exporta todo el
  histórico del usuario.
- Replica el patrón ya existente de `GetPresupuestoExcelQuery` (CQRS simple, no el
  paginado genérico): `GetGastosExcelQuery`/`GetIngresosExcelQuery` devuelven
  `PresupuestoArchivoDto` (reutilizado, misma forma `NombreArchivo`+`Contenido`).
- Nuevos repositorios Dapper `GastoExportRepository`/`IngresoExportRepository` con
  `WHERE` dinámico (mismas columnas/joins/`searchableColumns` que los
  `*ReadRepository` ya existentes), sin paginar.
- Nuevos `GastoExcelGenerator`/`IngresoExcelGenerator` (ClosedXML), mismo esquema
  visual que `PresupuestoExcelGenerator`.
- Verificado contra la BD de test (`AhorroLandTest`) con un proyecto de prueba que
  usa el código real: filtro por concepto/categoría/proveedor/cliente/fecha/texto
  cada uno por separado y combinados, aislamiento entre usuarios, listas vacías, y
  round-trip del Excel generado (ClosedXML) — todo correcto. También verificado en
  vivo end-to-end desde el diálogo del frontend ya implementado.

## Archivos modificados
- `Kash/Kash.Api/Controllers/GastosController.cs`
- `Kash/Kash.Api/Controllers/IngresosController.cs`
- `Kash/Kash.Infrastructure/DependencyInjection.cs`
- `Kash/Kash.Application/Features/Gastos/Queries/GetExcel/` (nuevo)
- `Kash/Kash.Application/Features/Ingresos/Queries/GetExcel/` (nuevo)
- `Kash/Kash.Application/Interfaces/IGastoExcelGenerator.cs` (nuevo)
- `Kash/Kash.Application/Interfaces/IGastoExportRepository.cs` (nuevo)
- `Kash/Kash.Application/Interfaces/IIngresoExcelGenerator.cs` (nuevo)
- `Kash/Kash.Application/Interfaces/IIngresoExportRepository.cs` (nuevo)
- `Kash/Kash.Infrastructure/Persistence/Query/GastoExportRepository.cs` (nuevo)
- `Kash/Kash.Infrastructure/Persistence/Query/IngresoExportRepository.cs` (nuevo)
- `Kash/Kash.Infrastructure/Reporting/GastoExcelGenerator.cs` (nuevo)
- `Kash/Kash.Infrastructure/Reporting/IngresoExcelGenerator.cs` (nuevo)
- `openspec/specs/exportacion-excel-gastos-ingresos/spec.md` (nuevo)
- `openspec/changes/archive/2026-08-21-exportacion-excel-gastos-ingresos/` (change archivado)