### PR TITLE
Upgrade SergioIzq kernel packages to 0.2.9

### DIFF
--- a/Kash/Kash.Api/Kash.Api.csproj
+++ b/Kash/Kash.Api/Kash.Api.csproj
@@ -12,8 +12,8 @@
 		     llegan ahora transitivamente desde SergioIzq.AspNetCore.Kernel -->
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.11" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="SergioIzq.Logging.HtmlFile" Version="0.2.6" />
-		<PackageReference Include="SergioIzq.AspNetCore.Kernel" Version="0.2.6" />
+		<PackageReference Include="SergioIzq.Logging.HtmlFile" Version="0.2.9" />
+		<PackageReference Include="SergioIzq.AspNetCore.Kernel" Version="0.2.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Kash/Kash.Infrastructure/Kash.Infrastructure.csproj
+++ b/Kash/Kash.Infrastructure/Kash.Infrastructure.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="QuestPDF" Version="2026.8.0" />
     <PackageReference Include="ClosedXML" Version="0.105.1" />
     <PackageReference Include="SergioIzq.Infrastructure.Kernel" Version="0.2.9" />
-    <PackageReference Include="SergioIzq.AspNetCore.Kernel" Version="0.2.6" />
+    <PackageReference Include="SergioIzq.AspNetCore.Kernel" Version="0.2.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates Kash.Api and Kash.Infrastructure to use SergioIzq.AspNetCore.Kernel 0.2.9, and bumps SergioIzq.Logging.HtmlFile to 0.2.9 in Kash.Api. This keeps internal SergioIzq package versions aligned across projects and pulls in the latest shared fixes/improvements.