### PR TITLE
Fix: revierto Mapster a 10.0.10 para arreglar caída en producción

### DIFF
--- a/Kash/Kash.Shared.Application/Kash.Shared.Application.csproj
+++ b/Kash/Kash.Shared.Application/Kash.Shared.Application.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mapster" Version="10.0.12" />
-    <PackageReference Include="Mapster.DependencyInjection" Version="10.0.12" />
+    <PackageReference Include="Mapster" Version="10.0.10" />
+    <PackageReference Include="Mapster.DependencyInjection" Version="10.0.10" />
     <PackageReference Include="SergioIzq.Application.Kernel" Version="0.2.9" />
   </ItemGroup>
 


### PR DESCRIPTION
El bump a 10.0.12 en abfb23f rompe binariamente a SergioIzq.Application.Kernel (0.2.6 y 0.2.9), que fue compilado contra la firma de MapWith de Mapster 10.0.10. Esto lanzaba MissingMethodException en MapsterConfig al arrancar, antes de builder.Build(), matando el proceso al instante (exit 0) y dejando kash-api en bucle de reinicio en el VPS -> Nginx sin upstream -> gateway timeout en toda petición (visto como error CORS en el navegador).


Claude-Session: https://claude.ai/code/session_01V5Nwm7mr6z3aomG7ZuX79N