### PR TITLE
archive: collation-case-insensitive-catalogos - collation case-insens…

### DIFF
--- a/openspec/changes/archive/2026-09-03-collation-case-insensitive-catalogos/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-03-collation-case-insensitive-catalogos/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/archive/2026-09-03-collation-case-insensitive-catalogos/design.md
+++ b/openspec/changes/archive/2026-09-03-collation-case-insensitive-catalogos/design.md
@@ -1,0 +1,35 @@
+## Context
+
+MySQL 8.0.43 (ver `Kash.Infrastructure/DependencyInjection.cs`, `MySqlServerVersion(new Version(8, 0, 43))`). La conexión (`SqlDbConnectionFactory`) fija `CharacterSet = "utf8mb4"` pero no una collation — la collation efectiva de cada columna es la que tiene definida en la tabla. Las 7 columnas `nombre` de catálogo son `VARCHAR(100)` (ver `*Configuration.cs` en `Kash.Infrastructure/Persistence/Command/Configurations`) y hoy usan una collation sensible a mayúsculas/acentos (probablemente heredada del charset/collation por defecto del servidor o de la tabla en el momento de creación — este repo no versiona el DDL original, ver proposal.md). Ver proposal.md - Why para el bug observado.
+
+Ninguna de las 7 tablas tiene un índice `UNIQUE` sobre `nombre` (confirmado revisando `Kash.Infrastructure/Persistence/Command/Configurations/{Categoria,Concepto,Cuenta,FormaPago,Proveedor,Cliente,Persona}Configuration.cs`: solo índices no únicos `(usuario, nombre)` para rendimiento de búsqueda). La deduplicación de nombres es responsabilidad de la capa de aplicación (`ExistsWithSameNameAsync` / `ExistsWithSameNameExceptAsync` en cada `*ReadRepository`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Orden alfabético case-insensitive y accent-insensitive al ordenar por `nombre` en las 7 tablas de catálogo, sin tocar código de aplicación ni el paquete de kernel.
+
+**Non-Goals:**
+- No se cambia la collation de ninguna otra columna (descripciones, tablas de movimientos, etc.) ni el charset/collation por defecto del servidor o la base de datos.
+- No se añade una restricción `UNIQUE` sobre `nombre` ni se resuelven duplicados existentes que solo difieran en mayúsculas/minúsculas o acentos — se documenta como efecto colateral en el proposal, pero deduplicar datos no es objetivo de este change.
+- No se toca `AbsReadRepository` (kernel): las consultas que construye ya son correctas una vez la collation deja de ser case-sensitive.
+
+## Decisions
+
+**Collation elegida: `utf8mb4_0900_ai_ci`.** Es la collation Unicode "accent/case-insensitive" nativa de MySQL 8.0 (ya en uso: 8.0.43 soporta `utf8mb4_0900_ai_ci` desde 8.0.0), coherente con el `CharacterSet = utf8mb4` ya configurado en la conexión. Alternativa descartada: `utf8mb4_unicode_ci`, pensada para compatibilidad con MySQL 5.x/MariaDB — no aporta nada aquí porque ya estamos en MySQL 8 y `_0900_ai_ci` tiene mejor soporte Unicode y mejor rendimiento en 8.0.
+
+**Alcance: las 7 columnas `nombre` de catálogo, no toda la base de datos.** Cambiar la collation por defecto del servidor/base de datos afectaría a tablas no relacionadas con este bug (movimientos, usuarios, etc.) sin necesidad — el problema observado es específicamente el orden alfabético de catálogos con nombre libre. Alternativa descartada: `ALTER DATABASE ... CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci` — cambia el default para tablas futuras pero no las existentes, así que igualmente habría que alterar cada tabla existente; se prefiere ser explícito por tabla.
+
+**Aplicación vía `schema.sql` manual, no vía capa de aplicación.** Sigue el patrón ya establecido en este repo (`openspec/changes/archive/2026-08-24-token-personal-api/schema.sql`): no hay EF Core Migrations, los cambios de esquema se documentan en el change y se aplican a mano contra cada entorno (dev, producción).
+
+## Risks / Trade-offs
+
+- **[Riesgo] Filas existentes que ya son duplicados case/accent-insensitive quedan sin fusionar.** La collation solo cambia cómo se comparan/ordenan los valores en consultas futuras, no reescribe datos. → Mitigación: ninguna requerida por este change (no hay `UNIQUE` que pueda romperse); si en el futuro se quiere fusionar duplicados, sería un change aparte, con decisión explícita de negocio sobre qué fila prevalece.
+- **[Riesgo] `ALTER TABLE ... MODIFY` reconstruye la tabla completa en InnoDB.** Con el volumen de datos actual (catálogos personales, no tablas de eventos) el bloqueo es breve, pero conviene aplicarlo en una ventana de bajo tráfico en producción. → Mitigación: ejecutar el script manualmente fuera de horas pico; no requiere cambio de código ni despliegue coordinado.
+- **[Trade-off] `ORDER BY` sobre una columna con collation `_ai_ci` no puede aprovechar un índice que use la collation anterior para el propósito de ordenar (case-sensitive), pero sí sigue sirviendo para búsquedas por igualdad/prefijo.** Los índices existentes (`(usuario, nombre)`) son no únicos y de rendimiento moderado dado el volumen por usuario; no se considera necesario recrearlos.
+
+## Migration Plan
+
+1. Aplicar `schema.sql` manualmente contra la base de datos de desarrollo local; verificar en la app que los 7 catálogos listan/buscan/previsualizan en orden alfabético case-insensitive (usar el mismo caso reproducido en la exploración: categorías `IA`, `Ocio`, `Sin clasificar`, `categoria`).
+2. Aplicar el mismo script contra producción en una ventana de bajo tráfico.
+3. Sin rollback de código (no hay cambios de código). Rollback de esquema: volver a `COLLATE` anterior por tabla si apareciera un problema no previsto (no se espera, dado que no hay índices `UNIQUE` afectados).

--- a/openspec/changes/archive/2026-09-03-collation-case-insensitive-catalogos/proposal.md
+++ b/openspec/changes/archive/2026-09-03-collation-case-insensitive-catalogos/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Las columnas `nombre` de los catálogos (categorías, conceptos, cuentas, formas de pago, proveedores, clientes, personas) usan una collation de MySQL sensible a mayúsculas/minúsculas. Todo el código que pide `ORDER BY nombre ASC` (listados paginados, autocompletado de búsqueda y el endpoint "recent" recién corregido para presentar en orden alfabético) ya hace lo correcto, pero MySQL ordena por valor de byte: los nombres que empiezan en mayúscula quedan siempre antes que los que empiezan en minúscula, en vez de mezclarse en el orden alfabético que un usuario espera. Verificado en vivo: con categorías `IA`, `Ocio`, `Sin clasificar`, `categoria`, tanto el listado de Categorías como el desplegable de Categoría en los modales de crear/editar Gasto/Ingreso muestran ese mismo orden — `categoria` queda al final en vez de ir primero.
+
+## What Changes
+
+- Se cambia la collation de la columna `nombre` (`VARCHAR(100)`) a `utf8mb4_0900_ai_ci` (case-insensitive y accent-insensitive, soportada por el MySQL 8.0.43 en uso) en las 7 tablas de catálogo: `categorias`, `conceptos`, `cuentas`, `formas_pago`, `proveedores`, `clientes`, `personas`.
+- Se aplica mediante un script `schema.sql` (este repo no usa EF Core Migrations; los cambios de esquema se documentan y aplican a mano, como en `openspec/changes/archive/2026-08-24-token-personal-api/schema.sql`).
+- Ningún cambio de código: `AbsReadRepository` (kernel) ya construye correctamente `ORDER BY nombre ASC` en los listados paginados, en `SearchForAutocompleteAsync` y en `GetRecentAsync`; el cambio de collation hace que ese `ASC` se comporte de forma alfabética case-insensitive sin tocar la consulta.
+- **Efecto colateral (deseado, no un objetivo en sí):** las comprobaciones de duplicados por nombre (`ExistsWithSameNameAsync` / `ExistsWithSameNameExceptAsync` en cada `*ReadRepository`, usadas al crear/renombrar un elemento de catálogo) pasan a considerar iguales dos nombres que solo difieren en mayúsculas/minúsculas o acentos (p. ej. "Ocio" y "ocio"). No hay índice `UNIQUE` a nivel de base de datos sobre `nombre` en ninguna de las 7 tablas (solo índices no únicos `(usuario, nombre)` para rendimiento), así que la migración no puede fallar por colisión de unicidad — pero si ya existen registros duplicados solo por mayúsculas/minúsculas, ambos seguirán existiendo (la collation no fusiona filas), y a partir de ahí la app empezará a tratarlos como el mismo nombre al validar duplicados.
+
+## Capabilities
+
+### New Capabilities
+- `orden-alfabetico-catalogos`: orden alfabético case-insensitive al listar, buscar o previsualizar los catálogos por nombre (categorías, conceptos, cuentas, formas de pago, proveedores, clientes, personas).
+
+### Modified Capabilities
+(ninguna — no hay spec existente que documente el orden de estos catálogos)
+
+## Impact
+
+- **Esquema de base de datos**: `schema.sql` de este change, con `ALTER TABLE ... MODIFY nombre VARCHAR(100) COLLATE utf8mb4_0900_ai_ci` para `categorias`, `conceptos`, `cuentas`, `formas_pago`, `proveedores`, `clientes`, `personas`. Aplicar manualmente sobre la base de datos (dev y producción); no requiere despliegue de código.
+- **Código**: ninguno. No se toca `Kash.Infrastructure`, `Kash.Application` ni el paquete `SergioIzq.Infrastructure.Kernel`.
+- **Consumidores**: `Kash-Frontend` no requiere cambios — ya pide orden alfabético explícito en el catálogo paginado y consume tal cual el orden de `/recent` y `/search`; con la collation corregida, los desplegables de crear/editar Gasto/Ingreso (y las pantallas de gestión de cada catálogo) mostrarán orden alfabético humano sin más cambios.

--- a/openspec/changes/archive/2026-09-03-collation-case-insensitive-catalogos/schema.sql
+++ b/openspec/changes/archive/2026-09-03-collation-case-insensitive-catalogos/schema.sql
@@ -1,0 +1,27 @@
+-- collation-case-insensitive-catalogos: collation case-insensitive/accent-insensitive
+-- para la columna `nombre` de los catálogos de nombre libre, para que ORDER BY nombre ASC
+-- (listados paginados, autocompletado y "recientes") ordene alfabéticamente como espera
+-- un humano, en vez de por valor de byte (mayúsculas antes que minúsculas).
+-- Aplicar manualmente sobre la base de datos MySQL (este repo no usa EF Core Migrations).
+-- Collation utf8mb4_0900_ai_ci: nativa de MySQL 8.0 (servidor en uso: 8.0.43).
+
+ALTER TABLE categorias
+    MODIFY nombre VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL;
+
+ALTER TABLE conceptos
+    MODIFY nombre VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL;
+
+ALTER TABLE cuentas
+    MODIFY nombre VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL;
+
+ALTER TABLE formas_pago
+    MODIFY nombre VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL;
+
+ALTER TABLE proveedores
+    MODIFY nombre VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL;
+
+ALTER TABLE clientes
+    MODIFY nombre VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL;
+
+ALTER TABLE personas
+    MODIFY nombre VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL;

--- a/openspec/changes/archive/2026-09-03-collation-case-insensitive-catalogos/specs/orden-alfabetico-catalogos/spec.md
+++ b/openspec/changes/archive/2026-09-03-collation-case-insensitive-catalogos/specs/orden-alfabetico-catalogos/spec.md
@@ -1,0 +1,20 @@
+## Purpose
+
+Garantizar que los catálogos de nombre libre (categorías, conceptos, cuentas, formas de pago, proveedores, clientes, personas) se listen, busquen y previsualicen en orden alfabético case-insensitive, tal y como lo esperaría una persona, en vez de por el valor de byte del nombre.
+
+## ADDED Requirements
+
+### Requirement: Orden alfabético case-insensitive de catálogos por nombre
+Cuando el sistema devuelve elementos de un catálogo (categorías, conceptos, cuentas, formas de pago, proveedores, clientes o personas) ordenados por nombre, el orden SHALL ser alfabético case-insensitive y accent-insensitive: dos nombres que solo difieren en mayúsculas/minúsculas o en acentos SHALL intercalarse según su forma base, no según el valor de byte de sus caracteres.
+
+#### Scenario: Listado paginado de un catálogo con nombres de distinta capitalización
+- **WHEN** un usuario tiene categorías `IA`, `Ocio`, `Sin clasificar` y `categoria`, y solicita el listado paginado de categorías ordenado por nombre ascendente
+- **THEN** el orden devuelto es `categoria`, `IA`, `Ocio`, `Sin clasificar`
+
+#### Scenario: Vista previa "recientes" de un catálogo con nombres de distinta capitalización
+- **WHEN** un usuario abre el selector de categoría en el formulario de crear/editar Gasto o Ingreso, que precarga el catálogo completo vía el endpoint de "recientes"
+- **THEN** las categorías se presentan en el mismo orden alfabético case-insensitive que el listado paginado, no por fecha de creación ni por valor de byte del nombre
+
+#### Scenario: Búsqueda por texto en un catálogo con nombres de distinta capitalización
+- **WHEN** un usuario busca un texto que coincide con varios nombres de catálogo que difieren solo en mayúsculas/minúsculas
+- **THEN** los resultados se devuelven en orden alfabético case-insensitive

--- a/openspec/changes/archive/2026-09-03-collation-case-insensitive-catalogos/tasks.md
+++ b/openspec/changes/archive/2026-09-03-collation-case-insensitive-catalogos/tasks.md
@@ -1,0 +1,14 @@
+## 1. Script de esquema
+
+- [x] 1.1 Escribir `schema.sql` con `ALTER TABLE ... MODIFY nombre VARCHAR(100) COLLATE utf8mb4_0900_ai_ci` para `categorias`, `conceptos`, `cuentas`, `formas_pago`, `proveedores`, `clientes` y `personas`, siguiendo el formato de `openspec/changes/archive/2026-08-24-token-personal-api/schema.sql`.
+
+## 2. Aplicación en desarrollo y verificación
+
+- [x] 2.1 Aplicar `schema.sql` contra la base de datos de desarrollo local y verificar con `SHOW FULL COLUMNS FROM <tabla>` que la columna `nombre` de las 7 tablas queda con collation `utf8mb4_0900_ai_ci`.
+- [x] 2.2 Con datos de prueba que mezclen mayúsculas/minúsculas (p. ej. categorías `IA`, `Ocio`, `Sin clasificar`, `categoria`), verificar en la app que el listado paginado de Categorías (`/categorias`) las muestra en orden alfabético case-insensitive (`categoria`, `IA`, `Ocio`, `Sin clasificar`).
+- [x] 2.3 Verificar en los modales de crear/editar Gasto e Ingreso (`Kash-Frontend`) que los desplegables de Categoría, Concepto, Cuenta, Forma de Pago, Proveedor/Cliente y Persona muestran el catálogo completo en el mismo orden alfabético case-insensitive al abrirlos en blanco.
+- [x] 2.4 Verificar que una búsqueda por texto que coincida con nombres de distinta capitalización (autocompletado) devuelve los resultados en orden alfabético case-insensitive.
+
+## 3. Aplicación en producción
+
+- [x] 3.1 Aplicar `schema.sql` contra la base de datos de producción en una ventana de bajo tráfico y repetir la verificación de collation (`SHOW FULL COLUMNS`) para las 7 tablas.

--- a/openspec/specs/orden-alfabetico-catalogos/spec.md
+++ b/openspec/specs/orden-alfabetico-catalogos/spec.md
@@ -1,0 +1,22 @@
+# orden-alfabetico-catalogos Specification
+
+## Purpose
+
+Garantizar que los catálogos de nombre libre (categorías, conceptos, cuentas, formas de pago, proveedores, clientes, personas) se listen, busquen y previsualicen en orden alfabético case-insensitive, tal y como lo esperaría una persona, en vez de por el valor de byte del nombre.
+
+## Requirements
+
+### Requirement: Orden alfabético case-insensitive de catálogos por nombre
+Cuando el sistema devuelve elementos de un catálogo (categorías, conceptos, cuentas, formas de pago, proveedores, clientes o personas) ordenados por nombre, el orden SHALL ser alfabético case-insensitive y accent-insensitive: dos nombres que solo difieren en mayúsculas/minúsculas o en acentos SHALL intercalarse según su forma base, no según el valor de byte de sus caracteres.
+
+#### Scenario: Listado paginado de un catálogo con nombres de distinta capitalización
+- **WHEN** un usuario tiene categorías `IA`, `Ocio`, `Sin clasificar` y `categoria`, y solicita el listado paginado de categorías ordenado por nombre ascendente
+- **THEN** el orden devuelto es `categoria`, `IA`, `Ocio`, `Sin clasificar`
+
+#### Scenario: Vista previa "recientes" de un catálogo con nombres de distinta capitalización
+- **WHEN** un usuario abre el selector de categoría en el formulario de crear/editar Gasto o Ingreso, que precarga el catálogo completo vía el endpoint de "recientes"
+- **THEN** las categorías se presentan en el mismo orden alfabético case-insensitive que el listado paginado, no por fecha de creación ni por valor de byte del nombre
+
+#### Scenario: Búsqueda por texto en un catálogo con nombres de distinta capitalización
+- **WHEN** un usuario busca un texto que coincide con varios nombres de catálogo que difieren solo en mayúsculas/minúsculas
+- **THEN** los resultados se devuelven en orden alfabético case-insensitive


### PR DESCRIPTION
…itive en nombre de catálogos

## Motivo del change
Las columnas `nombre` de los catálogos (categorías, conceptos, cuentas, formas de pago, proveedores, clientes, personas) usaban una collation de MySQL sensible a mayúsculas/minúsculas, así que `ORDER BY nombre ASC` ordenaba por valor de byte (mayúsculas siempre antes que minúsculas) en vez de alfabéticamente. Reproducido en vivo: con categorías `IA`, `Ocio`, `Sin clasificar`, `categoria`, tanto el listado de Categorías como los desplegables de crear/editar Gasto/Ingreso mostraban `categoria` al final en vez de ir primero.

## Descripción de la solución
Se cambió la collation de la columna `nombre` (VARCHAR(100)) a `utf8mb4_0900_ai_ci` en las 7 tablas de catálogo, vía `schema.sql` aplicado manualmente (este repo no usa EF Core Migrations). Sin cambios de código: las consultas `ORDER BY nombre ASC` ya eran correctas, solo la collation estaba mal. Aplicado y verificado en la base de datos de desarrollo (listado paginado, "recientes" en los modales de Gasto/Ingreso, y búsqueda por texto); la aplicación en producción queda a cargo del usuario.

## Archivos modificados
- openspec/changes/archive/2026-09-03-collation-case-insensitive-catalogos/ (proposal, design, specs, tasks, schema.sql)
- openspec/specs/orden-alfabetico-catalogos/spec.md (nueva capability)